### PR TITLE
Added css for styling the staff cards

### DIFF
--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -1267,4 +1267,21 @@ position:static;
 width:auto; 
 height:auto; 
 } 
+
+/* staff contact card styles */
+.contact-card .wrap-contact-image {
+  display: inline-block; 
+  vertical-align: middle; 
+  margin-right: 15px;
+}
+
+.contact-card .wrap-contact-info {
+  display: inline-block; 
+  vertical-align: middle;
+}
+
+.contact-card .wrap-contact-help {
+  display: block;
+}
+
 </style>


### PR DESCRIPTION
This PR adds a bit of css to help style the LibGuides staff directory cards that are using more semantic (non-table) markup. 

Code review: @matt-bernhardt 
FYI: @darcyduke 