### PR TITLE
add browzine customizations

### DIFF
--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -1284,4 +1284,20 @@ height:auto;
   display: block;
 }
 
+/* customize browzine widget */
+#browzineWidget .smallWidget {
+  width: auto !important;
+  float: none !important;
+  background-size: contain !important;
+}
+
+#browzineWidget .smallWidget .widgetText {
+  width: auto !important;
+  float: none !important;
+  padding: 10px;
+}
+
+#browzineWidget .widgetText .intro {
+  text-align: center !important;
+}
 </style>


### PR DESCRIPTION
This PR adds some custom css to adjust the display of the new libguides browzine object. (screenshots before and after are below)

Code review: @matt-bernhardt 
FYI: @darcyduke 

<hr />
**Before:**
![before](https://cloud.githubusercontent.com/assets/4327102/15077562/0875b81a-137d-11e6-9710-09a498b6637a.png)

![before-smallscreen](https://cloud.githubusercontent.com/assets/4327102/15077653/6cf26dc4-137d-11e6-99d9-96a1c097e799.png)

<hr />
**After:**
![after](https://cloud.githubusercontent.com/assets/4327102/15077522/cd44b5de-137c-11e6-8953-5f88db88b272.png)

![after-smallscreen](https://cloud.githubusercontent.com/assets/4327102/15077645/69458ef4-137d-11e6-87f4-dc5afb336dcb.png)
