### PR TITLE
Adds Google Analytics with form submission event listener

### DIFF
--- a/libcal/custom-analytics.html
+++ b/libcal/custom-analytics.html
@@ -16,7 +16,7 @@
       hitType: 'event',
       eventCategory: 'LibCal',
       eventAction: 'Form Submission',
-      eventLabel: $('input[name="event_id"]').val()
+      eventLabel: $('h1').text().trim()
     });
   });
 </script>

--- a/libcal/custom-analytics.html
+++ b/libcal/custom-analytics.html
@@ -1,0 +1,22 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-1760176-1',  'auto', {'allowLinker': true});
+  ga('require', 'linker');
+  ga('linker:autoLink', ['libguides.mit.edu', 'libcal.mit.edu', 'libanswers.mit.edu'] );
+  ga('send', 'pageview');
+
+  // This detects form submissions (which should only be event registrations)
+  // Those events are submitted to Google Analytics
+  $( 'form' ).submit(function( event ) {
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'LibCal',
+      eventAction: 'Form Submission',
+      eventLabel: $('input[name="event_id"]').val()
+    });
+  });
+</script>


### PR DESCRIPTION
Because event registrations under LibCal don't result in a new pageview (the form is submitted via JS, and replaced with an in-page thank you message), we need some way of recording registrations via Events.

This listens for _all_ form submissions under LibCal, and records an Event in Google Analytics for each instance. Submissions are recorded with the following three values:

Category: LibCal
Action: Form submission
Label: _Form ID_

I'm reasonably confident in the Category value here, and pretty confident in the Action value. The Label value, however, is problematic. Using the Event ID is suitably specific, but it is also pretty opaque. I'm leaning towards grabbing the value of the `<h1>` tag, which in the current case would be `MIT Reads- An evening with author Ken Liu` rather than `3228188`

Tagging @frrrances for review, and @hllavina as an FYI (I don't know how much we've talked yet about our work with Springshare)