### PR TITLE
767 catchup

### DIFF
--- a/libanswers/custom-footer.html
+++ b/libanswers/custom-footer.html
@@ -33,7 +33,7 @@
 				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
 				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
 				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing software</a>
+				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
 				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
 			</div>
 			<div class="flex-item">

--- a/libanswers/custom-footer.html
+++ b/libanswers/custom-footer.html
@@ -8,7 +8,7 @@
 				<a href="https://libraries.mit.edu/vera" class="link-sub">Vera: E-journals &amp; databases</a>
 				<a href="https://libraries.mit.edu/worldcat" class="link-sub">WorldCat</a>
 				<a href="https://libraries.mit.edu/barton-reserves" class="link-sub">Course reserves</a>
-				<a href="https://libraries.mit.edu/about/site-search" class="link-sub">Site search</a>
+				<a href="https://libraries.mit.edu/site-search" class="link-sub">Site search</a>
 				<a href="https://libraries.mit.edu/search" class="link-sub">More search options</a>
 			</div>
 			<div class="flex-item">
@@ -33,7 +33,7 @@
 				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
 				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
 				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
+				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing software</a>
 				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
 			</div>
 			<div class="flex-item">
@@ -42,7 +42,7 @@
 				<a href="https://libraries.mit.edu/news" class="link-sub">News</a>
 				<a href="https://libraries.mit.edu/events" class="link-sub">Classes &amp; events</a>
 				<a href="https://libraries.mit.edu/use-policies" class="link-sub">Use policy</a>
-				<a href="https://libraries.mit.edu/about/site-search/" class="link-sub">Services A-Z</a>
+				<a href="https://libraries.mit.edu/site-search/" class="link-sub">Services A-Z</a>
 				<a href="https://libraries.mit.edu/about" class="link-sub">More about us</a>
 			</div>
 		</div><!-- end div.links-all -->
@@ -57,10 +57,12 @@
 				<p class="text-find-us">Find us on</p>
 					<a href="https://twitter.com/mitlibraries" title="Twitter">
 						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
+						<span class="sr">Twitter</span>
 					</a><!-- End Twitter -->
 					
 					<a href="https://libraries.mit.edu/facebook" title="Facebook">
 						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
+						<span class="sr">Facebook</span>
 					</a><!-- End Facebook -->
 					
 					<a href="https://instagram.com/mitlibraries/" title="Instagram">
@@ -73,16 +75,20 @@
 	 M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z
 	 M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
 	c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
+						<span class="sr">Instagram</span>
+
 					</a><!-- End Instagram -->
 					
-					<a href="http://libguides.mit.edu/mit-feeds" title="RSS">
+					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
+						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+						<span class="sr">YouTube</span>
+					</a><!-- End YouTube -->
+
+					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
 						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
+						<span class="sr">RSS</span>
 					</a><!-- End RSS -->
-					
-					<a href="https://www.flickr.com/photos/mit-libraries/" title="Flickr">
-						<svg class="icon-social--flickr" width="2048" height="2048" viewBox="-320 -384 2048 2048" enable-background="new 0 -128 1536 1536" xml:space="preserve"><path d="M698 640c0-58.7-20.7-108.7-62-150s-91.3-62-150-62 -108.7 20.7-150 62 -62 91.3-62 150 20.7 108.7 62 150 91.3 62 150 62 108.7-20.7 150-62S698 698.7 698 640zM1262 640c0-58.7-20.7-108.7-62-150s-91.3-62-150-62 -108.7 20.7-150 62 -62 91.3-62 150 20.7 108.7 62 150 91.3 62 150 62 108.7-20.7 150-62S1262 698.7 1262 640z"/></svg>
-					</a><!-- End Flickr -->
-					
+
 			</div><!-- end div.social -->
 			
 			<div class="links-primary flex-container">

--- a/libanswers/custom-header.html
+++ b/libanswers/custom-header.html
@@ -28,7 +28,7 @@
             <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
             <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
@@ -37,11 +37,10 @@
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-            <li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
-            <li><a href="https://libraries.mit.edu/libx">LibX <span class="about">Search/authenticate via browser</span></a></li>
-            <li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
-            <li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/about/site-search">Site search</a></li>
+            <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
+            <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
+            <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/site-search">Site search</a></li>
           </ul>
         </div>
       </div><!-- end div.links-sub -->
@@ -58,10 +57,10 @@
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
-            <li><a href="https://libraries.mit.edu/archives">Distinctive Collections</a></li>
+            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
+            <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
             <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>
@@ -89,8 +88,8 @@
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-            <li><a href="http://library.mit.edu">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
             <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
@@ -100,8 +99,8 @@
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
-            <li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
+            <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
           </ul>
         </div>
@@ -119,7 +118,7 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/offcampus">Connect from on and off-campus <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, LibX, RSS, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, RSS, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
@@ -127,10 +126,10 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">Publishing &amp; content management</h3>
           <ul class="list-unbulleted">
-            <li><a href="http://libguides.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
-            <li><a href="http://libguides.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="http://libguides.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
+            <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
           </ul>
         </div>
@@ -138,17 +137,16 @@
     </li><!-- end div.links-primary -->
     <li class="link-primary flex-end">
       <h2 class="main-nav-header">
-        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About us</a>
-        <button class="menu-control sr">About us menu</button>
+        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About</a>
+        <button class="menu-control sr">About menu</button>
       </h2>
       <div aria-labelledby="main-nav-aboutmenu-title" id="main-nav-aboutmenu" class="links-sub flex-container push group">
         <div class="col-1 flex-item">
-          <h3 class="heading-col">About us</h3>
+          <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/about/organization">About our organization</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
-            <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
-            <li><a href="https://libraries.mit.edu/about/experiments/">Experiments at the Libraries</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>
             <li><a href="https://libraries.mit.edu/about" class="bottom">More about us</a></li>
           </ul>
@@ -159,6 +157,7 @@
           <a href="https://libraries.mit.edu/news">News</a>
           <a href="https://libraries.mit.edu/exhibits">Exhibits &amp; galleries</a>
           <a href="https://libraries.mit.edu/news/in-the-media">In the media</a>
+          <a href="https://libraries.mit.edu/mit-reads/">MIT Reads</a>
         </div>
       </div><!-- end div.links-sub -->
     </li><!-- end div.links-primary -->

--- a/libcal/custom-footer.html
+++ b/libcal/custom-footer.html
@@ -33,7 +33,7 @@
 				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
 				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
 				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing software</a>
+				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
 				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
 			</div>
 			<div class="flex-item">

--- a/libcal/custom-footer.html
+++ b/libcal/custom-footer.html
@@ -8,7 +8,7 @@
 				<a href="https://libraries.mit.edu/vera" class="link-sub">Vera: E-journals &amp; databases</a>
 				<a href="https://libraries.mit.edu/worldcat" class="link-sub">WorldCat</a>
 				<a href="https://libraries.mit.edu/barton-reserves" class="link-sub">Course reserves</a>
-				<a href="https://libraries.mit.edu/about/site-search" class="link-sub">Site search</a>
+				<a href="https://libraries.mit.edu/site-search" class="link-sub">Site search</a>
 				<a href="https://libraries.mit.edu/search" class="link-sub">More search options</a>
 			</div>
 			<div class="flex-item">
@@ -33,7 +33,7 @@
 				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
 				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
 				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
+				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing software</a>
 				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
 			</div>
 			<div class="flex-item">
@@ -42,7 +42,7 @@
 				<a href="https://libraries.mit.edu/news" class="link-sub">News</a>
 				<a href="https://libraries.mit.edu/events" class="link-sub">Classes &amp; events</a>
 				<a href="https://libraries.mit.edu/use-policies" class="link-sub">Use policy</a>
-				<a href="https://libraries.mit.edu/about/site-search/" class="link-sub">Services A-Z</a>
+				<a href="https://libraries.mit.edu/site-search/" class="link-sub">Services A-Z</a>
 				<a href="https://libraries.mit.edu/about" class="link-sub">More about us</a>
 			</div>
 		</div><!-- end div.links-all -->
@@ -57,10 +57,12 @@
 				<p class="text-find-us">Find us on</p>
 					<a href="https://twitter.com/mitlibraries" title="Twitter">
 						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
+						<span class="sr">Twitter</span>
 					</a><!-- End Twitter -->
 					
 					<a href="https://libraries.mit.edu/facebook" title="Facebook">
 						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
+						<span class="sr">Facebook</span>
 					</a><!-- End Facebook -->
 					
 					<a href="https://instagram.com/mitlibraries/" title="Instagram">
@@ -73,16 +75,20 @@
 	 M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z
 	 M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
 	c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
+						<span class="sr">Instagram</span>
+
 					</a><!-- End Instagram -->
 					
-					<a href="http://libguides.mit.edu/mit-feeds" title="RSS">
+					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
+						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+						<span class="sr">YouTube</span>
+					</a><!-- End YouTube -->
+
+					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
 						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
+						<span class="sr">RSS</span>
 					</a><!-- End RSS -->
-					
-					<a href="https://www.flickr.com/photos/mit-libraries/" title="Flickr">
-						<svg class="icon-social--flickr" width="2048" height="2048" viewBox="-320 -384 2048 2048" enable-background="new 0 -128 1536 1536" xml:space="preserve"><path d="M698 640c0-58.7-20.7-108.7-62-150s-91.3-62-150-62 -108.7 20.7-150 62 -62 91.3-62 150 20.7 108.7 62 150 91.3 62 150 62 108.7-20.7 150-62S698 698.7 698 640zM1262 640c0-58.7-20.7-108.7-62-150s-91.3-62-150-62 -108.7 20.7-150 62 -62 91.3-62 150 20.7 108.7 62 150 91.3 62 150 62 108.7-20.7 150-62S1262 698.7 1262 640z"/></svg>
-					</a><!-- End Flickr -->
-					
+
 			</div><!-- end div.social -->
 			
 			<div class="links-primary flex-container">

--- a/libcal/custom-header.html
+++ b/libcal/custom-header.html
@@ -28,7 +28,7 @@
             <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
             <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
@@ -37,11 +37,10 @@
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-            <li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
-            <li><a href="https://libraries.mit.edu/libx">LibX <span class="about">Search/authenticate via browser</span></a></li>
-            <li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
-            <li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/about/site-search">Site search</a></li>
+            <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
+            <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
+            <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/site-search">Site search</a></li>
           </ul>
         </div>
       </div><!-- end div.links-sub -->
@@ -58,10 +57,10 @@
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
-            <li><a href="https://libraries.mit.edu/archives">Distinctive Collections</a></li>
+            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
+            <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
             <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>
@@ -89,8 +88,8 @@
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-            <li><a href="http://library.mit.edu">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
             <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
@@ -100,8 +99,8 @@
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
-            <li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
+            <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
           </ul>
         </div>
@@ -119,7 +118,7 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/offcampus">Connect from on and off-campus <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, LibX, RSS, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, RSS, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
@@ -127,10 +126,10 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">Publishing &amp; content management</h3>
           <ul class="list-unbulleted">
-            <li><a href="http://libguides.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
-            <li><a href="http://libguides.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="http://libguides.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
+            <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
           </ul>
         </div>
@@ -138,17 +137,16 @@
     </li><!-- end div.links-primary -->
     <li class="link-primary flex-end">
       <h2 class="main-nav-header">
-        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About us</a>
-        <button class="menu-control sr">About us menu</button>
+        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About</a>
+        <button class="menu-control sr">About menu</button>
       </h2>
       <div aria-labelledby="main-nav-aboutmenu-title" id="main-nav-aboutmenu" class="links-sub flex-container push group">
         <div class="col-1 flex-item">
-          <h3 class="heading-col">About us</h3>
+          <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/about/organization">About our organization</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
-            <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
-            <li><a href="https://libraries.mit.edu/about/experiments/">Experiments at the Libraries</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>
             <li><a href="https://libraries.mit.edu/about" class="bottom">More about us</a></li>
           </ul>
@@ -159,6 +157,7 @@
           <a href="https://libraries.mit.edu/news">News</a>
           <a href="https://libraries.mit.edu/exhibits">Exhibits &amp; galleries</a>
           <a href="https://libraries.mit.edu/news/in-the-media">In the media</a>
+          <a href="https://libraries.mit.edu/mit-reads/">MIT Reads</a>
         </div>
       </div><!-- end div.links-sub -->
     </li><!-- end div.links-primary -->

--- a/libguides/custom-footer.html
+++ b/libguides/custom-footer.html
@@ -33,7 +33,7 @@
 				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
 				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
 				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing software</a>
+				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
 				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
 			</div>
 			<div class="flex-item">

--- a/libguides/custom-footer.html
+++ b/libguides/custom-footer.html
@@ -8,7 +8,7 @@
 				<a href="https://libraries.mit.edu/vera" class="link-sub">Vera: E-journals &amp; databases</a>
 				<a href="https://libraries.mit.edu/worldcat" class="link-sub">WorldCat</a>
 				<a href="https://libraries.mit.edu/barton-reserves" class="link-sub">Course reserves</a>
-				<a href="https://libraries.mit.edu/about/site-search" class="link-sub">Site search</a>
+				<a href="https://libraries.mit.edu/site-search" class="link-sub">Site search</a>
 				<a href="https://libraries.mit.edu/search" class="link-sub">More search options</a>
 			</div>
 			<div class="flex-item">
@@ -33,7 +33,7 @@
 				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
 				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
 				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
+				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing software</a>
 				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
 			</div>
 			<div class="flex-item">
@@ -42,7 +42,7 @@
 				<a href="https://libraries.mit.edu/news" class="link-sub">News</a>
 				<a href="https://libraries.mit.edu/events" class="link-sub">Classes &amp; events</a>
 				<a href="https://libraries.mit.edu/use-policies" class="link-sub">Use policy</a>
-				<a href="https://libraries.mit.edu/about/site-search/" class="link-sub">Services A-Z</a>
+				<a href="https://libraries.mit.edu/site-search/" class="link-sub">Services A-Z</a>
 				<a href="https://libraries.mit.edu/about" class="link-sub">More about us</a>
 			</div>
 		</div><!-- end div.links-all -->
@@ -57,10 +57,12 @@
 				<p class="text-find-us">Find us on</p>
 					<a href="https://twitter.com/mitlibraries" title="Twitter">
 						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
+						<span class="sr">Twitter</span>
 					</a><!-- End Twitter -->
 					
 					<a href="https://libraries.mit.edu/facebook" title="Facebook">
 						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
+						<span class="sr">Facebook</span>
 					</a><!-- End Facebook -->
 					
 					<a href="https://instagram.com/mitlibraries/" title="Instagram">
@@ -73,16 +75,20 @@
 	 M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z
 	 M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
 	c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
+						<span class="sr">Instagram</span>
+
 					</a><!-- End Instagram -->
 					
-					<a href="http://libguides.mit.edu/mit-feeds" title="RSS">
+					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
+						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+						<span class="sr">YouTube</span>
+					</a><!-- End YouTube -->
+
+					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
 						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
+						<span class="sr">RSS</span>
 					</a><!-- End RSS -->
-					
-					<a href="https://www.flickr.com/photos/mit-libraries/" title="Flickr">
-						<svg class="icon-social--flickr" width="2048" height="2048" viewBox="-320 -384 2048 2048" enable-background="new 0 -128 1536 1536" xml:space="preserve"><path d="M698 640c0-58.7-20.7-108.7-62-150s-91.3-62-150-62 -108.7 20.7-150 62 -62 91.3-62 150 20.7 108.7 62 150 91.3 62 150 62 108.7-20.7 150-62S698 698.7 698 640zM1262 640c0-58.7-20.7-108.7-62-150s-91.3-62-150-62 -108.7 20.7-150 62 -62 91.3-62 150 20.7 108.7 62 150 91.3 62 150 62 108.7-20.7 150-62S1262 698.7 1262 640z"/></svg>
-					</a><!-- End Flickr -->
-					
+
 			</div><!-- end div.social -->
 			
 			<div class="links-primary flex-container">

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -157,6 +157,7 @@
           <a href="https://libraries.mit.edu/news">News</a>
           <a href="https://libraries.mit.edu/exhibits">Exhibits &amp; galleries</a>
           <a href="https://libraries.mit.edu/news/in-the-media">In the media</a>
+          <a href="https://libraries.mit.edu/mit-reads/">MIT Reads</a>
         </div>
       </div><!-- end div.links-sub -->
     </li><!-- end div.links-primary -->

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -57,10 +57,10 @@
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
-            <li><a href="https://libraries.mit.edu/archives">Distinctive Collections</a></li>
+            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
+            <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
             <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -137,12 +137,12 @@
     </li><!-- end div.links-primary -->
     <li class="link-primary flex-end">
       <h2 class="main-nav-header">
-        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About us</a>
-        <button class="menu-control sr">About us menu</button>
+        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About</a>
+        <button class="menu-control sr">About menu</button>
       </h2>
       <div aria-labelledby="main-nav-aboutmenu-title" id="main-nav-aboutmenu" class="links-sub flex-container push group">
         <div class="col-1 flex-item">
-          <h3 class="heading-col">About us</h3>
+          <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/about/organization">About our organization</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -148,7 +148,6 @@
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
             <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
-            <li><a href="https://libraries.mit.edu/about/experiments/">Experiments at the Libraries</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>
             <li><a href="https://libraries.mit.edu/about" class="bottom">More about us</a></li>
           </ul>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -38,7 +38,6 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
             <li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
-            <li><a href="https://libraries.mit.edu/libx">LibX <span class="about">Search/authenticate via browser</span></a></li>
             <li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
             <li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/about/site-search">Site search</a></li>
@@ -119,7 +118,7 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/offcampus">Connect from on and off-campus <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, LibX, RSS, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, RSS, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -146,7 +146,6 @@
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/about/organization">About our organization</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
-            <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>
             <li><a href="https://libraries.mit.edu/about" class="bottom">More about us</a></li>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -28,7 +28,7 @@
             <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
             <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
@@ -37,10 +37,10 @@
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-            <li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
-            <li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
-            <li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/about/site-search">Site search</a></li>
+            <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
+            <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
+            <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/site-search">Site search</a></li>
           </ul>
         </div>
       </div><!-- end div.links-sub -->
@@ -88,8 +88,8 @@
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-            <li><a href="http://library.mit.edu">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
             <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
@@ -99,8 +99,8 @@
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
-            <li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
+            <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
           </ul>
         </div>
@@ -126,10 +126,10 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">Publishing &amp; content management</h3>
           <ul class="list-unbulleted">
-            <li><a href="http://libguides.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
-            <li><a href="http://libguides.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="http://libguides.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
+            <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
           </ul>
         </div>

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -144,6 +144,7 @@
         <div class="col-1 flex-item">
           <h3 class="heading-col">About us</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/about/organization">About our organization</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
             <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>

--- a/libwizard/custom-header.html
+++ b/libwizard/custom-header.html
@@ -28,7 +28,7 @@
             <li><a href="https://libraries.mit.edu/quicksearch">Quick search <span class="about">Books, articles, and more at MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/vera">Vera <span class="about">E-journals &amp; databases</span></a></li>
             <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Classic catalog search</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat<span class="about">Books &amp; more worldwide</span></a></li>
             <li><a href="https://libraries.mit.edu/barton-reserves">Course reserves</a></li>
             <li><a href="https://libraries.mit.edu/search" class="bottom extra"><span>More search tools &amp; help</span> <span class="about">Images, data, DSpace, etc.</span></a></li>
           </ul>
@@ -37,11 +37,10 @@
           <h3 class="heading-col">Also try</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/fulltext">FullText Finder <span class="about">Find specific citations</span></a></li>
-            <li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
-            <li><a href="https://libraries.mit.edu/libx">LibX <span class="about">Search/authenticate via browser</span></a></li>
-            <li><a href="http://dspace.mit.edu/">DSpace@MIT <span class="about">MIT research</span></a></li>
-            <li><a href="http://dome.mit.edu/">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
-            <li><a href="https://libraries.mit.edu/about/site-search">Site search</a></li>
+            <li><a href="https://libraries.mit.edu/google-scholar-tips">Google Scholar for MIT <span class="about">Change settings to get better access</span></a></li>
+            <li><a href="https://libraries.mit.edu/dspace">DSpace@MIT <span class="about">MIT research</span></a></li>
+            <li><a href="https://libraries.mit.edu/dome">Dome <span class="about">MIT-digitized images, maps, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/site-search">Site search</a></li>
           </ul>
         </div>
       </div><!-- end div.links-sub -->
@@ -58,10 +57,10 @@
             <li><a href="https://libraries.mit.edu/barker">Barker Library</a></li>
             <li><a href="https://libraries.mit.edu/dewey">Dewey Library</a></li>
             <li><a href="https://libraries.mit.edu/hayden">Hayden Library</a></li>
-            <li><a href="https://libraries.mit.edu/archives">Distinctive Collections</a></li>
+            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
+            <li><a href="https://libraries.mit.edu/distinctive-collections">Distinctive Collections</a></li>
             <li><a href="https://libraries.mit.edu/music">Lewis Music Library</a></li>
             <li><a href="https://libraries.mit.edu/lsa">Library Storage Annex</a></li>
-            <li><a href="https://libraries.mit.edu/rotch">Rotch Library</a></li>
             <li><a href="https://libraries.mit.edu/hours" class="bottom">All hours &amp; locations</a></li>
           </ul>
         </div>
@@ -89,8 +88,8 @@
           <h3 class="heading-col">Renew, request, suggest</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/barton-account">Your Account <span class="about">Renew MIT items</span></a></li>
-            <li><a href="http://library.mit.edu">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
-            <li><a href="http://mit.worldcat.org">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/barton">Barton catalog <span class="about">Request items owned by MIT</span></a></li>
+            <li><a href="https://libraries.mit.edu/worldcat">WorldCat <span class="about">Request items not owned by MIT</span></a></li>
             <li><a href="https://libraries.mit.edu/illiad">ILLiad <span class="about">Track your Interlibrary Borrowing requests</span></a></li>
             <li><a href="https://libraries.mit.edu/suggest-purchase">Suggest a purchase</a></li>
             <li><a href="https://libraries.mit.edu/borrow" class="bottom">More options &amp; help</a></li>
@@ -100,8 +99,8 @@
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
             <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
-            <li><a href="http://libguides.mit.edu/circfaq">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
+            <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>
           </ul>
         </div>
@@ -119,7 +118,7 @@
             <li><a href="https://libraries.mit.edu/ask">Ask us <span class="about">Email, chat, call, drop by</span></a></li>
             <li><a href="https://libraries.mit.edu/experts">Research guides &amp; expert librarians <span class="about">For every research interest</span></a></li>
             <li><a href="https://libraries.mit.edu/offcampus">Connect from on and off-campus <span class="about">Tips &amp; tricks</span></a></li>
-            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, LibX, RSS, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/productivity-tools">Productivity tools <span class="about">Apps, RSS, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/new-books">New books by subject <span class="about">Browse or subscribe to RSS feeds</span></a></li>
             <li><a href="https://libraries.mit.edu/research-support" class="bottom">More research support</a></li>
           </ul>
@@ -127,10 +126,10 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">Publishing &amp; content management</h3>
           <ul class="list-unbulleted">
-            <li><a href="http://libguides.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
-            <li><a href="http://libguides.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
-            <li><a href="http://libguides.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
-            <li><a href="http://libguides.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
+            <li><a href="https://libraries.mit.edu/references">Citation &amp; writing tools <span class="about">Mendeley, Zotero, &amp; Overleaf</span></a></li>
+            <li><a href="https://libraries.mit.edu/citing">Citing sources <span class="about">Avoid plagiarism, format references, etc.</span></a></li>
+            <li><a href="https://libraries.mit.edu/manage-info">Manage your info &amp; data <span class="about">Organize your data, files, and more</span></a></li>
+            <li><a href="https://libraries.mit.edu/publishing">Getting published <span class="about">Tools &amp; help</span></a></li>
             <li><a href="https://libraries.mit.edu/scholarly">Scholarly publishing <span class="about">Open access &amp; copyright</span></a></li>
           </ul>
         </div>
@@ -138,17 +137,16 @@
     </li><!-- end div.links-primary -->
     <li class="link-primary flex-end">
       <h2 class="main-nav-header">
-        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About us</a>
-        <button class="menu-control sr">About us menu</button>
+        <a id="main-nav-aboutmenu-title" href="https://libraries.mit.edu/about" class="no-underline main-nav-link">About</a>
+        <button class="menu-control sr">About menu</button>
       </h2>
       <div aria-labelledby="main-nav-aboutmenu-title" id="main-nav-aboutmenu" class="links-sub flex-container push group">
         <div class="col-1 flex-item">
-          <h3 class="heading-col">About us</h3>
+          <h3 class="heading-col">About the Libraries</h3>
           <ul class="list-unbulleted">
+            <li><a href="https://libraries.mit.edu/about/organization">About our organization</a></li>
             <li><a href="https://libraries.mit.edu/contact">Contact us</a></li>
-            <li><a href="https://libraries.mit.edu/use-policies">Library use policy</a></li>
             <li><a href="https://libraries.mit.edu/jobs">Jobs</a></li>
-            <li><a href="https://libraries.mit.edu/about/experiments/">Experiments at the Libraries</a></li>
             <li><a href="https://libraries.mit.edu/giving">Giving to the MIT Libraries</a></li>
             <li><a href="https://libraries.mit.edu/about" class="bottom">More about us</a></li>
           </ul>
@@ -159,6 +157,7 @@
           <a href="https://libraries.mit.edu/news">News</a>
           <a href="https://libraries.mit.edu/exhibits">Exhibits &amp; galleries</a>
           <a href="https://libraries.mit.edu/news/in-the-media">In the media</a>
+          <a href="https://libraries.mit.edu/mit-reads/">MIT Reads</a>
         </div>
       </div><!-- end div.links-sub -->
     </li><!-- end div.links-primary -->


### PR DESCRIPTION
This applies changes to the Springshare branding elements that have already been put into place on libraries.mit.edu. Not every product uses all the elements (LibWizard doesn't provide a branded footer, for example) - but this updates those elements that we use.

Please note: without a staging server, we apply these changes directly to production - so these are already live. We can make adjustments easily, though.