### PR TITLE
Replace full footer with updated slim footer and remove GetIt link

### DIFF
--- a/libanswers/custom-footer.html
+++ b/libanswers/custom-footer.html
@@ -1,121 +1,77 @@
-<footer class="footer-main-wrap">
-	<div class="footer-main flex-container">
-		<div class="links-all flex-container">
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/search">Search</a></h4>
-				<a href="https://libraries.mit.edu/quicksearch" class="link-sub">Quick search</a>
-				<a href="https://libraries.mit.edu/barton" class="link-sub">Barton catalog</a>
-				<a href="https://libraries.mit.edu/vera" class="link-sub">Vera: E-journals &amp; databases</a>
-				<a href="https://libraries.mit.edu/worldcat" class="link-sub">WorldCat</a>
-				<a href="https://libraries.mit.edu/barton-reserves" class="link-sub">Course reserves</a>
-				<a href="https://libraries.mit.edu/site-search" class="link-sub">Site search</a>
-				<a href="https://libraries.mit.edu/search" class="link-sub">More search options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/hours">Hours &amp; locations</a></h4>
-				<a href="https://libraries.mit.edu/hours" class="link-sub">Hours</a>
-				<a href="https://libraries.mit.edu/locations" class="link-sub">Map of locations</a>
-				<a href="https://libraries.mit.edu/study" class="link-sub">Study spaces</a>
-				<a href="https://libraries.mit.edu/exhibits" class="link-sub">Exhibits &amp; galleries</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/borrow">Borrow &amp; request</a></h4>
-				<a href="https://libraries.mit.edu/barton-account" class="link-sub">Your Account</a>
-				<a href="https://libraries.mit.edu/getit" class="link-sub">Get it: options for getting books &amp; articles</a>
-				<a href="https://libraries.mit.edu/circ" class="link-sub">Circulation FAQ</a>
-				<a href="https://libraries.mit.edu/reserves" class="link-sub">Reserves &amp; TIP FAQ</a>
-				<a href="https://libraries.mit.edu/otherlibraries" class="link-sub">Visit non-MIT libraries</a>
-				<a href="https://libraries.mit.edu/borrow" class="link-sub">More borrow &amp; request options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/research-support">Research support</a></h4>
-				<a href="https://libraries.mit.edu/ask" class="link-sub">Ask us</a>
-				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
-				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
-				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
-				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/about">About us</a></h4>
-				<a href="https://libraries.mit.edu/contact" class="link-sub">Contact us</a>
-				<a href="https://libraries.mit.edu/news" class="link-sub">News</a>
-				<a href="https://libraries.mit.edu/events" class="link-sub">Classes &amp; events</a>
-				<a href="https://libraries.mit.edu/use-policies" class="link-sub">Use policy</a>
-				<a href="https://libraries.mit.edu/site-search/" class="link-sub">Services A-Z</a>
-				<a href="https://libraries.mit.edu/about" class="link-sub">More about us</a>
-			</div>
-		</div><!-- end div.links-all -->
-		
-		<div class="identity flex-container">
-			<a href="https://libraries.mit.edu/" class="logo-mit-lib" alt="MIT Libraries Logo">
-				<svg xmlns="http://www.w3.org/2000/svg" width="193.9" height="77.55" viewBox="0 0 193.9 77.55"><title>MIT Libraries logo</title><path d="M5.3,5.55H17.2L21.55,21.2q0.25,0.85.58,2.22T22.8,26.1q0.4,1.55.8,3.25h0.1q0.35-1.7.75-3.25,0.3-1.3.65-2.67t0.6-2.22L30.1,5.55h12V41.3H34V21.58q0-1.17,0-2.37,0-1.4.1-3.05H34q-0.4,1.55-.7,2.85t-0.53,2.22q-0.28,1.08-.42,1.58L27.25,41.3h-7.3l-5.1-18.45q-0.15-.5-0.45-1.6T13.85,19q-0.3-1.3-.65-2.85H13.1q0,1.65,0,3.05,0,1.2.08,2.4t0,1.75v18h-8V5.55Zm40,0h8.85V41.3H45.32V5.55ZM67.4,13H57V5.55H86.75V13H76.25V41.3H67.4V13ZM5.3,46.55h8.85V74.8H30.82v7.5H5.3V46.55Zm28.7,0h8.15v6.6H34v-6.6ZM34,56.7h8.15V82.3H34V56.7ZM61,83.1a9.84,9.84,0,0,1-4.55-1,7.87,7.87,0,0,1-3.2-3h-0.1V82.3h-7.8V46.55h8.15v13h0.15A9.45,9.45,0,0,1,56.55,57a8.63,8.63,0,0,1,4.37-1,9.89,9.89,0,0,1,4.53,1,10.16,10.16,0,0,1,3.45,2.85,13.44,13.44,0,0,1,2.2,4.3,17.91,17.91,0,0,1,.78,5.38,19.49,19.49,0,0,1-.78,5.72,12.5,12.5,0,0,1-2.2,4.28,9.47,9.47,0,0,1-3.45,2.67A10.66,10.66,0,0,1,61,83.1Zm-2.3-6.45a4.14,4.14,0,0,0,3.67-1.92,9.45,9.45,0,0,0,1.28-5.27,9.74,9.74,0,0,0-1.28-5.3,4.19,4.19,0,0,0-3.77-2,4.44,4.44,0,0,0-4,2.1,9.66,9.66,0,0,0-1.33,5.25,8.53,8.53,0,0,0,1.45,5.17A4.69,4.69,0,0,0,58.67,76.65ZM73.81,56.7h7.8v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27Q82,66.6,82,70.8V82.3H73.81V56.7ZM99.76,83a12,12,0,0,1-3.53-.5A7.54,7.54,0,0,1,93.46,81a7,7,0,0,1-1.8-2.45A8.11,8.11,0,0,1,91,75.15a7.29,7.29,0,0,1,.78-3.52,6.67,6.67,0,0,1,2.12-2.35A10.55,10.55,0,0,1,97,67.85a25.72,25.72,0,0,1,3.77-.75,24.65,24.65,0,0,0,5-1,1.92,1.92,0,0,0,1.45-1.85,2.57,2.57,0,0,0-.83-2,3.92,3.92,0,0,0-2.67-.75,4.45,4.45,0,0,0-3,.85,3.67,3.67,0,0,0-1.2,2.45h-7.5a8.46,8.46,0,0,1,.8-3.4,8.17,8.17,0,0,1,2.17-2.8,10.56,10.56,0,0,1,3.58-1.9,16.34,16.34,0,0,1,5-.7,19.62,19.62,0,0,1,4.9.52,9.73,9.73,0,0,1,3.4,1.58,7.29,7.29,0,0,1,2.45,3,10.63,10.63,0,0,1,.8,4.25V78.3a13,13,0,0,0,.17,2.42,1.78,1.78,0,0,0,.73,1.23V82.3h-7.9a3.37,3.37,0,0,1-.5-1.12,14.64,14.64,0,0,1-.35-1.72h-0.1A8.47,8.47,0,0,1,104.44,82,9.92,9.92,0,0,1,99.76,83Zm2.6-5.2a5.45,5.45,0,0,0,3.73-1.25,4.23,4.23,0,0,0,1.42-3.35v-3a11.85,11.85,0,0,1-1.87.73q-1.08.33-2.33,0.63a10.45,10.45,0,0,0-3.4,1.27,2.47,2.47,0,0,0-1.05,2.17,2.42,2.42,0,0,0,1,2.2A4.5,4.5,0,0,0,102.36,77.75Zm15.87-21H126v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.23,1.83-2.23,6V82.3h-8.15V56.7Zm18.94-10.15h8.15v6.6h-8.15v-6.6Zm0,10.15h8.15V82.3h-8.15V56.7Zm24,26.35a15.16,15.16,0,0,1-5.7-1,12.12,12.12,0,0,1-4.3-2.85,12.66,12.66,0,0,1-2.7-4.33,15.06,15.06,0,0,1-1-5.4,14.72,14.72,0,0,1,1-5.33,12.71,12.71,0,0,1,2.7-4.3A12.46,12.46,0,0,1,155.3,57a14.58,14.58,0,0,1,10.28-.17,12.28,12.28,0,0,1,3.83,2.35,12.76,12.76,0,0,1,3.42,5.33,20.72,20.72,0,0,1,1.08,7.13H155.5a7.52,7.52,0,0,0,1.8,4.1,5.14,5.14,0,0,0,4,1.5,4.81,4.81,0,0,0,2.65-.68,4.3,4.3,0,0,0,1.6-1.87h8a9.47,9.47,0,0,1-1.5,3.33,10.65,10.65,0,0,1-2.8,2.73,12.12,12.12,0,0,1-3.58,1.75A15.22,15.22,0,0,1,161.15,83Zm4.5-16.3a6,6,0,0,0-1.55-3.65,4.39,4.39,0,0,0-3.3-1.35,4.66,4.66,0,0,0-3.6,1.35,7,7,0,0,0-1.65,3.65h10.1Zm21.9,16.35q-5.65,0-8.95-2.42A8.35,8.35,0,0,1,175.1,74h7.7a4.15,4.15,0,0,0,1.45,2.85,5.09,5.09,0,0,0,3.25,1,5.63,5.63,0,0,0,2.92-.65,2.09,2.09,0,0,0,1.08-1.9,1.82,1.82,0,0,0-.55-1.37,4.08,4.08,0,0,0-1.45-.85,10.92,10.92,0,0,0-2.08-.5q-1.17-.17-2.42-0.42-1.65-.3-3.3-0.72a10.14,10.14,0,0,1-3-1.28,6.33,6.33,0,0,1-2.12-2.27,7.45,7.45,0,0,1-.8-3.68,7.1,7.1,0,0,1,.87-3.55A7.64,7.64,0,0,1,179,58a11.18,11.18,0,0,1,3.53-1.55,17,17,0,0,1,4.28-.52q5.45,0,8.35,2.2a8,8,0,0,1,3.2,6h-7.5a3,3,0,0,0-1.33-2.37,5.48,5.48,0,0,0-2.78-.62,5.1,5.1,0,0,0-2.52.58,1.9,1.9,0,0,0-1,1.78,1.33,1.33,0,0,0,.5,1.1,4.21,4.21,0,0,0,1.35.67,14.86,14.86,0,0,0,2,.48l2.33,0.4q1.7,0.3,3.42.73A10.59,10.59,0,0,1,196,68.2a7.05,7.05,0,0,1,2.32,2.42,7.75,7.75,0,0,1,.9,4A7.35,7.35,0,0,1,195.9,81a11.75,11.75,0,0,1-3.7,1.6A18.75,18.75,0,0,1,187.54,83.1Z" transform="translate(-5.3 -5.55)" /></svg>
-				<span class="sr">MIT Libraries</span>
-			</a><!-- End MIT Libraries Logo -->
-			
-			<div class="social flex-container">
-				<p class="text-find-us">Find us on</p>
-					<a href="https://twitter.com/mitlibraries" title="Twitter">
-						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
-						<span class="sr">Twitter</span>
-					</a><!-- End Twitter -->
-					
-					<a href="https://libraries.mit.edu/facebook" title="Facebook">
-						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
-						<span class="sr">Facebook</span>
-					</a><!-- End Facebook -->
-					
-					<a href="https://instagram.com/mitlibraries/" title="Instagram">
-						<svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2
-	c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1
-	c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4
-	C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0
-	c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4
-	c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z
-	 M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z
-	 M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
-	c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
-						<span class="sr">Instagram</span>
+<footer>
+<div class="wrap-outer-footer layout-band">
+    <div class="wrap-footer footer-slim">
+        <div class="footer-main" aria-label="MIT Libraries footer">
+            <div class="identity">
+                <div class="wrap-logo-lib">
+                    <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="194.05" height="77.65" viewBox="0 0 194.05 77.65"><title>MIT Libraries Logo</title><path d="M0,0H11.9l4.35,15.65q0.25,0.85.58,2.22t0.67,2.68q0.4,1.55.8,3.25h0.1q0.35-1.7.75-3.25,0.3-1.3.65-2.67t0.6-2.22L24.8,0h12V35.75H28.7V13.66q0-1.4.1-3.05H28.7q-0.4,1.55-.7,2.85t-0.53,2.22q-0.28,1.08-.42,1.58l-5.1,18.49h-7.3L9.55,17.3Q9.4,16.8,9.1,15.7T8.55,13.45q-0.3-1.3-.65-2.85H7.8v3.05q0,1.2.08,2.4a9.26,9.26,0,0,1,0,1.75v18h-8V0H0ZM40,0h8.85V35.75H40V0h0ZM62.1,7.45H51.7V0H81.45V7.45H70.95v28.3H62.1V7.45ZM0,41H8.85V69.25H25.52v7.5H0V41Zm28.7,0h8.15v6.6H28.7V41Zm0,10.15h8.15v25.6H28.7V51.15Zm27,26.4a9.84,9.84,0,0,1-4.55-1,7.87,7.87,0,0,1-3.2-3h-0.1v3.2h-7.8V41H48.2V54h0.15a9.45,9.45,0,0,1,2.9-2.55,8.63,8.63,0,0,1,4.37-1,9.89,9.89,0,0,1,4.53,1A10.16,10.16,0,0,1,63.6,54.3a13.44,13.44,0,0,1,2.2,4.3A17.91,17.91,0,0,1,66.58,64a19.49,19.49,0,0,1-.78,5.72A12.5,12.5,0,0,1,63.6,74a9.47,9.47,0,0,1-3.45,2.67A10.66,10.66,0,0,1,55.7,77.55ZM53.4,71.1a4.14,4.14,0,0,0,3.67-1.92,9.45,9.45,0,0,0,1.28-5.27,9.74,9.74,0,0,0-1.28-5.3,4.19,4.19,0,0,0-3.77-2,4.44,4.44,0,0,0-4,2.1A9.66,9.66,0,0,0,48,64a8.53,8.53,0,0,0,1.45,5.17,4.69,4.69,0,0,0,4,2h0Zm15.11-20h7.8v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.16,1.78-2.16,6v11.5H68.51V51.15Zm26,26.3a12,12,0,0,1-3.53-.5,7.54,7.54,0,0,1-2.77-1.5A7,7,0,0,1,86.36,73a8.11,8.11,0,0,1-.66-3.4,7.29,7.29,0,0,1,.78-3.52,6.67,6.67,0,0,1,2.12-2.35,10.55,10.55,0,0,1,3.1-1.43,25.72,25.72,0,0,1,3.77-.75,24.65,24.65,0,0,0,5-1,1.92,1.92,0,0,0,1.45-1.85,2.57,2.57,0,0,0-.83-2A3.92,3.92,0,0,0,98.42,56a4.45,4.45,0,0,0-3,.85,3.67,3.67,0,0,0-1.2,2.45h-7.5a8.46,8.46,0,0,1,.8-3.4,8.17,8.17,0,0,1,2.17-2.8,10.56,10.56,0,0,1,3.58-1.9,16.34,16.34,0,0,1,5-.7,19.62,19.62,0,0,1,4.9.52,9.73,9.73,0,0,1,3.4,1.58,7.29,7.29,0,0,1,2.45,3,10.63,10.63,0,0,1,.8,4.25V72.75a13,13,0,0,0,.17,2.42,1.78,1.78,0,0,0,.73,1.23v0.35h-7.9a3.37,3.37,0,0,1-.5-1.12,14.64,14.64,0,0,1-.35-1.72h-0.1a8.47,8.47,0,0,1-2.73,2.54A9.92,9.92,0,0,1,94.46,77.45Zm2.6-5.2A5.45,5.45,0,0,0,100.79,71a4.23,4.23,0,0,0,1.42-3.35v-3a11.85,11.85,0,0,1-1.87.73Q99.26,65.71,98,66a10.45,10.45,0,0,0-3.4,1.27,2.47,2.47,0,0,0-1.05,2.17,2.42,2.42,0,0,0,1,2.2,4.5,4.5,0,0,0,2.5.55v0.05Zm15.87-21h7.77v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.23,1.83-2.23,6V76.75h-8.15V51.15ZM131.87,41.1H140v6.6h-8.15V41.1Zm0,10.15H140v25.5h-8.15V51.25Zm24,26.35a15.16,15.16,0,0,1-5.7-1,12.12,12.12,0,0,1-4.3-2.85,12.66,12.66,0,0,1-2.7-4.33,15.06,15.06,0,0,1-1-5.4,14.72,14.72,0,0,1,1-5.33,12.71,12.71,0,0,1,2.7-4.3A12.46,12.46,0,0,1,150,51.45a14.58,14.58,0,0,1,10.28-.17,12.28,12.28,0,0,1,3.83,2.35A12.76,12.76,0,0,1,167.53,59a20.72,20.72,0,0,1,1.08,7.13H150.2a7.52,7.52,0,0,0,1.8,4.1,5.14,5.14,0,0,0,4,1.5,4.81,4.81,0,0,0,2.65-.68,4.3,4.3,0,0,0,1.6-1.87h8a9.47,9.47,0,0,1-1.5,3.33,10.65,10.65,0,0,1-2.8,2.73A12.12,12.12,0,0,1,160.37,77a15.22,15.22,0,0,1-4.52.5Zm4.5-16.3a6,6,0,0,0-1.55-3.65,4.39,4.39,0,0,0-3.3-1.35,4.66,4.66,0,0,0-3.6,1.35,7,7,0,0,0-1.65,3.65h10.1Zm21.9,16.35q-5.65,0-8.95-2.42a8.35,8.35,0,0,1-3.52-6.78h7.7a4.15,4.15,0,0,0,1.45,2.85,5.09,5.09,0,0,0,3.25,1,5.63,5.63,0,0,0,2.92-.65,2.09,2.09,0,0,0,1.08-1.9,1.82,1.82,0,0,0-.55-1.37,4.08,4.08,0,0,0-1.45-.85,10.92,10.92,0,0,0-2.08-.5q-1.17-.17-2.42-0.42-1.65-.3-3.3-0.72a10.14,10.14,0,0,1-3-1.28,6.33,6.33,0,0,1-2.12-2.27,7.45,7.45,0,0,1-.8-3.68,7.1,7.1,0,0,1,.87-3.55,7.64,7.64,0,0,1,2.35-2.66,11.18,11.18,0,0,1,3.53-1.55,17,17,0,0,1,4.28-.52q5.45,0,8.35,2.2a8,8,0,0,1,3.2,6h-7.5a3,3,0,0,0-1.33-2.37,5.48,5.48,0,0,0-2.78-.62,5.1,5.1,0,0,0-2.52.58,1.9,1.9,0,0,0-1,1.78,1.33,1.33,0,0,0,.5,1.1,4.21,4.21,0,0,0,1.35.67,14.86,14.86,0,0,0,2,.48l2.33,0.4q1.7,0.3,3.42.73a10.59,10.59,0,0,1,3.17,1.32A7.05,7.05,0,0,1,193,65.07a7.75,7.75,0,0,1,.9,4,7.35,7.35,0,0,1-3.32,6.38,11.75,11.75,0,0,1-3.7,1.6,18.75,18.75,0,0,1-4.66.5Z" transform="translate(0.12)" fill="#fff"/></svg>
+                    </a>
+                </div>
+                <div class="wrap-social">
+                    <p class="text-find-us">Find us on</p>
+                    <a href="//twitter.com/mitlibraries" title="Twitter">
+                        <svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black"></path></g></svg>
+                        <span class="sr">Twitter</span>
+                    </a><!-- End Twitter -->
+                    
+                    <a href="https://www.facebook.com/mitlib" title="Facebook">
+                        <svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black"></path></g></svg>
+                        <span class="sr">Facebook</span>
+                    </a><!-- End Facebook -->
+                    
+                    <a href="//instagram.com/mitlibraries/" title="Instagram">
+                        <svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1 c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4 C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0 c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4 c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"></path></svg>
+                        <span class="sr">Instagram</span>
+                    </a><!-- End Instagram -->
+                    
+                    <a href="//www.youtube.com/user/MITLibraries" title="YouTube">
+                        <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+                        <span class="sr">YouTube</span>
+                    </a><!-- End YouTube -->
 
-					</a><!-- End Instagram -->
-					
-					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
-						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
-						<span class="sr">YouTube</span>
-					</a><!-- End YouTube -->
-
-					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
-						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
-						<span class="sr">RSS</span>
-					</a><!-- End RSS -->
-
-			</div><!-- end div.social -->
-			
-			<div class="links-primary flex-container">
-				<span><a href="https://libraries.mit.edu/faculty" class="link-sub">Faculty</a></span>
-				<span><a href="https://libraries.mit.edu/alumni" class="link-sub">Alumni</a></span>
-				<span><a href="https://libraries.mit.edu/visitors" class="link-sub">Visitors</a></span>
-				<span><a href="https://libraries.mit.edu/giving" class="link-sub">Giving</a></span>
-				<span><a href="https://libraries.mit.edu/disabilities" class="link-sub">Persons with disabilities</a></span>
-			</div><!-- End div.links-primary -->
-			
-		</div><!-- End div.identity -->
-	</div>
-	
-	<div class="footer-info-institute">
-		<a class="link-logo-mit" href="http://www.mit.edu">
-			<span class="sr">MIT</span>
-			<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
-		</a><!-- End MIT Logo -->
-		
-		<div class="about-mit">
-			<span>MASSACHUSETTS INSTITUTE OF TECHNOLOGY </span>
-			<span>77 MASSACHUSETTS AVENUE </span>
-			<span>CAMBRIDGE MA 02139-4307</span>
-		</div><!-- End div.about-mit -->
-		
-		<div class="license">Licensed under the <a href="http://creativecommons.org/licenses/by-nc/2.0/" class="license-cc">Creative Commons Attribution Non-Commercial License</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
-		</div><!-- End footer.footer-info-institure -->
-	</div>
+                    <a href="//libguides.mit.edu/mit-feeds" title="RSS">
+                        <svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black"></path></g></svg>
+                        <span class="sr">RSS</span>
+                    </a><!-- End RSS -->
+                </div><!-- end .social -->
+                <div class="wrap-middle">
+                    <div class="wrap-sitemap">
+                        <nav class="sitemap-libraries-abbrev" aria-label="MIT Libraries site menu">
+                            <h2 class="sr">MIT Libraries navigation</h2>
+                            <a class="item" href="https://libraries.mit.edu/search">Search</a>
+                            <a class="item" href="https://libraries.mit.edu/hours">Hours &amp; locations</a>
+                            <a class="item" href="https://libraries.mit.edu/borrow">Borrow &amp; request</a>
+                            <a class="item" href="https://libraries.mit.edu/research-support">Research support</a>
+                            <a class="item" href="https://libraries.mit.edu/about">About us</a>
+                        </nav>
+                    </div><!-- end .links-all -->
+                    <div class="wrap-policies">
+                        <nav aria-label="MIT Libraries policy menu">
+                            <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+                            <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
+                            <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
+                        </nav>
+                    </div>
+                </div>
+            </div><!-- end .identity -->
+        </div>
+    </div>
+</div>
+<div class="wrap-outer-footer-institute layout-band">
+    <div class="wrap-footer-institute">
+        <div class="footer-info-institute">
+            <a class="link-logo-mit" href="https://www.mit.edu">
+                <span class="sr">MIT</span>
+                <svg version="1.1" xmlns="https://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
+            </a>
+            <div class="about-mit">
+                <span class="item">Massachusetts Institute of Technology</span>
+            </div>
+            <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
+            </div><!-- end .footer-info-institute -->
+        </div>
+    </div>
+</div>
 </footer>
 <script src="//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88"></script>

--- a/libanswers/custom-head.html
+++ b/libanswers/custom-head.html
@@ -802,407 +802,336 @@ svg {
 }
 
 /* 2. Footer */
-.footer-main {
-  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+.wrap-footer {
+  font-size: 12px;
+}
+.wrap-footer .wrap-policies, .wrap-footer.footer-slim .sitemap-libraries-abbrev a {
+  padding-left: 0;
+}
+.wrap-footer .wrap-policies li, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li,
+.wrap-footer .wrap-policies .item,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item {
+  display: inline-block;
+  padding-right: 1rem;
+}
+.wrap-footer .wrap-policies li:after, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li:after,
+.wrap-footer .wrap-policies .item:after,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item:after {
+  content: ' | ';
+  margin-left: 1rem;
+}
+.wrap-footer .wrap-policies li:last-child:after, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li:last-child:after,
+.wrap-footer .wrap-policies .item:last-child:after,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item:last-child:after {
+  content: '';
+}
+.layout-band:after {
+  content: '';
+  display: table;
   clear: both;
-  width: 100%
+}
+.wrap-footer,
+.wrap-footer-institute {
+  max-width: 114rem;
+  margin: 0 auto;
+  padding: 10px 4%;
+}
+.wrap-footer:after,
+.wrap-footer-institute:after {
+  content: '';
+  display: table;
+  clear: both;
+}
+.wrap-outer-footer {
+  background-color: #000;
+  color: #fff;
+  font-size: 1.2em;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-main {
-    padding: 2em 1.375em
-  }
+.wrap-footer {
+  padding: 3.5rem 4%;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main {
-    width: 100%
-  }
+.wrap-footer .wrap-sitemap .menu-sub {
+  display: none;
 }
-
-.footer-main a {
-  color: #fff
+.wrap-footer .identity {
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
-
-.footer-main .identity {
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 2em 0 0
+.wrap-footer .wrap-logo-lib {
+  display: inline-block;
+  vertical-align: bottom;
+  margin: 0 20px 20px 0;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main .identity {
-    -webkit-box-align: end;
-    -webkit-align-items: flex-end;
-    -ms-flex-align: end;
-    align-items: flex-end;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-    width: 100%
-  }
+.wrap-footer .wrap-social {
+  display: inline-block;
+  vertical-align: bottom;
+  margin-bottom: 20px;
 }
-
-.footer-main .links-all {
-  display: none
+.wrap-footer .wrap-policies {
+  width: 100%;
+  border-top: 1px solid #595959;
+  padding-top: 2rem;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all {
+.wrap-footer .wrap-policies span {
+  display: inline-block;
+  margin: 1rem 1.5rem 1rem 0;
+}
+.wrap-footer .wrap-policies span.item {
+  margin-right: 0;
+}
+.wrap-footer .wrap-policies span:after {
+  content: '';
+}
+.wrap-footer .wrap-social .text-find-us {
+  display: none;
+}
+@media (min-width: 768px) {
+  .wrap-footer .wrap-sitemap {
     display: -webkit-box;
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    width: 100%
-  }
-}
-
-.footer-main .links-all h4 {
-  font-size: 1.125em;
-  font-weight: 400;
-  padding-bottom: 1em
-}
-
-.footer-main .links-all .flex-item {
-  margin-right: 1.75em
-}
-
-.footer-main .links-all .link-sub {
-  display: block;
-  font-size: .75em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all .link-sub {
-    font-size: .75em;
-    font-weight: 300
-  }
-  .footer-main .links-all .link-sub:not(:last-of-type) {
-    padding-bottom: 1em
-  }
-}
-
-.footer-main .links-primary {
-  border-top: 1px solid #808285;
-  border-bottom: 1px solid #808285;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  font-size: .8125em;
-  margin-top: 2em;
-  padding: 2rem 1.375rem;
-  width: 100%
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary {
-    border-top: none;
-    border-bottom: none;
-    font-size: .875em;
-    margin-top: -22.4px;
-    margin-top: -1.4rem;
-    margin-left: 184px;
-    margin-left: 11.5rem;
-    padding: 0;
-    z-index: 3000
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary {
-    margin-top: 24px;
-    margin-top: 1.5rem;
-    margin-left: 0;
-    margin-left: 0
-  }
-}
-
-.footer-main .links-primary span {
-  display: block;
-  width: 50%
-}
-
-.footer-main .links-primary span:not(:last-of-type) {
-  margin-bottom: 1.5em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary span {
-    font-weight: 300;
-    padding-left: 1em;
-    width: auto
-  }
-  .footer-main .links-primary span:not(:last-of-type):after {
-    color: #dedede;
-    content: '|';
-    display: inline-block;
-    margin-left: 1em
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary span:first-of-type {
-    padding-left: 0
-  }
-}
-
-.footer-main .logo-mit-lib {
-  display: block;
-  fill: #fff;
-  padding-left: 1.375em;
-  width: 10.3125em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .logo-mit-lib {
-    padding-left: 0;
-    max-width: 9.5em;
-    width: 9.5em
-  }
-}
-
-.footer-main .logo-mit-lib svg {
-  max-height: 4em;
-  max-width: 9.5em
-}
-
-.footer-main .text-find-us {
-  color: #fff;
-  display: none;
-  font-size: .625em;
-  font-weight: 700;
-  text-transform: uppercase;
-  min-width: 7em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .text-find-us {
-    display: block
-  }
-}
-
-.footer-main .social {
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding-left: 1.375em;
-  width: auto
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    margin-bottom: -.8em;
-    z-index: 4000
-  }
-}
-
-.footer-main .social a {
-  width: 33%
-}
-
-.footer-main .social a:hover {
-  text-decoration: none
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social a {
-    width: 20%
-  }
-  .footer-main .social a:not(:last-of-type) {
-    margin-right: .5em
-  }
-}
-
-.footer-main .social [class*=icon-social] {
-  background: #fff;
-  -webkit-border-radius: 50%;
-  border-radius: 50%;
-  height: 1.5em;
-  padding: .2em;
-  width: 1.5em
-}
-
-.footer-main .social [class*=icon-social] path {
-  fill: #000
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social [class*=icon-social] {
-    height: 2em;
-    padding: .2em;
-    width: 2em
-  }
-}
-
-.footer-info-institute {
-  -webkit-box-align: baseline;
-  -webkit-align-items: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-  background: #333;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 1.5em 1em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute {
     -webkit-box-orient: horizontal;
     -webkit-box-direction: normal;
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row
+        -ms-flex-direction: row;
+            flex-direction: row;
+  }
+  .wrap-footer .wrap-sitemap .col {
+    margin-right: 3%;
+  }
+  .wrap-footer .wrap-sitemap .col:last-child {
+    margin-right: 0;
+  }
+  .wrap-footer .wrap-sitemap .menu-sub {
+    display: block;
+  }
+  .wrap-footer .identity {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
+    margin: 4% 0 0 0;
+  }
+  .wrap-footer .wrap-logo-lib,
+  .wrap-footer .wrap-policies,
+  .wrap-footer .wrap-social {
+    -ms-flex-item-align: end;
+        align-self: flex-end;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .wrap-footer .wrap-logo-lib {
+    -webkit-box-ordinal-group: 2;
+        -ms-flex-order: 1;
+            order: 1;
+    margin-right: 4%;
+  }
+  .wrap-footer .wrap-policies {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+    padding: auto;
+    border-top: none;
+    width: auto;
+  }
+  .wrap-footer .wrap-policies span {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .wrap-footer .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+    margin-left: auto;
+  }
+}
+@media (min-width: 1024px) {
+  .wrap-footer .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+  }
+  .wrap-footer .wrap-policies {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
   }
 }
 
-.footer-info-institute .about-mit {
-  font-size: .625em;
-  margin-bottom: 2em
+.wrap-footer.footer-slim {
+  padding: 1.5rem 4%;
 }
-
-.footer-info-institute .about-mit span {
-  color: #eee;
-  text-transform: uppercase
+.wrap-footer.footer-slim .wrap-middle {
+  -webkit-box-ordinal-group: 3;
+      -ms-flex-order: 2;
+          order: 2;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: start;
+      -ms-flex-align: start;
+          align-items: flex-start;
 }
-
-.footer-info-institute .about-mit span:first-of-type {
-  font-weight: 700
+.wrap-footer.footer-slim .wrap-middle .wrap-policies {
+  -ms-flex-item-align: start;
+      align-self: flex-start;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute .about-mit span {
-    color: #ededed
+.wrap-footer.footer-slim .wrap-middle .wrap-sitemap {
+  display: inline-block;
+  margin-bottom: 2rem;
+}
+.wrap-footer.footer-slim .wrap-middle .wrap-sitemap .item {
+  display: block;
+  margin-right: 10px;
+  margin-bottom: 5px;
+}
+@media (min-width: 768px) {
+  .wrap-footer.footer-slim .wrap-middle {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
   }
-  .footer-info-institute .about-mit span:not(:last-of-type):after {
-    content: '|';
-    font-weight: 400
+  .wrap-footer.footer-slim .wrap-middle .wrap-policies {
+    margin-left: 2%;
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+  }
+  .wrap-footer.footer-slim .wrap-middle .wrap-sitemap {
+    display: inline-block;
+    margin-left: 2%;
+    margin-bottom: auto;
+    -webkit-box-ordinal-group: 2;
+        -ms-flex-order: 1;
+            order: 1;
+  }
+  .wrap-footer.footer-slim .wrap-middle .wrap-sitemap .item {
+    display: inline-block;
+    margin-bottom: auto;
+  }
+  .wrap-footer.footer-slim .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
   }
 }
 
-.footer-info-institute .license {
-  color: #ededed;
-  font-size: .6875em;
-  width: 100%
+.wrap-footer-institute {
+  padding: 20px 4%;
 }
 
-.footer-info-institute .license a {
-  color: #ededed
+.wrap-content li {
+  margin-bottom: .5em;
+}
+.wrap-content .title-page {
+  margin-bottom: 1rem;
+  padding: .5rem 0 1rem 0;
+  font-weight: 600;
 }
 
-.footer-info-institute .link-mit-home {
-  display: block
+.wrap-footer {
+  background: #000 url("https://libraries.mit.edu/images/vi-shape7-tp.png") no-repeat 10%;
+}
+.wrap-footer a {
+  color: #fff;
+  text-decoration: none;
+}
+.wrap-footer a:hover, .wrap-footer a:active, .wrap-footer a:focus {
+  text-decoration: underline;
+  color: #fff;
+}
+.wrap-footer .title {
+  margin-bottom: .8rem;
+}
+.wrap-footer .wrap-list .link-sub {
+  display: list-item;
+  list-style-type: none;
+  margin-bottom: .65rem;
+  font-weight: 300;
+}
+.wrap-footer .logo-mit-lib {
+  fill: #fff;
+}
+.wrap-footer .logo-mit-lib svg {
+  max-height: 60px;
+  max-width: 100%;
+  vertical-align: baseline;
+}
+.wrap-footer .wrap-policies {
+  font-size: 1.4em;
+}
+.wrap-footer .wrap-social p, .wrap-footer .wrap-social a {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: .5rem;
+  margin-bottom: 0;
+  text-transform: uppercase;
+  font-size: 1.2em;
+}
+.wrap-footer .wrap-social svg {
+  height: 2em;
+  width: 2em;
+  border-radius: 50%;
+  padding: 0.2em;
+  background: #fff none repeat scroll 0 0;
+}
+.wrap-footer .wrap-social svg path {
+  fill: #333;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-info-institute .link-mit-home {
-    margin: 0 1em 1.5em 0
-  }
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a {
+  font-size: 1.4em;
 }
 
-.footer-info-institute .logo-mit {
-  fill: #bbb9b8;
-  width: 3.375em
+.wrap-outer-footer-institute {
+  background-color: #333;
+  font-size: 12px;
+  color: #dedede;
 }
-
-.footer-info-institute .logo-mit .color {
-  fill: #ededed
+.wrap-outer-footer-institute .footer-info-institute {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
 }
-
-.no-flexbox .footer-info-institute {
-  display: block
+.wrap-outer-footer-institute a {
+  color: #fff;
 }
-
-.no-flexbox .footer-info-institute:after {
-  clear: both;
-  content: '';
-  display: table
+.wrap-outer-footer-institute a:hover, .wrap-outer-footer-institute a:active, .wrap-outer-footer-institute a:focus {
+  color: #fff;
 }
-
-.no-flexbox .footer-info-institute>a,
-.no-flexbox .footer-info-institute>div {
-  float: left
+.wrap-outer-footer-institute .link-logo-mit .logo-mit {
+  fill: #ccc;
 }
-
-.no-flexbox .footer-info-institute .about-mit {
-  padding-top: 4em
+.wrap-outer-footer-institute .link-logo-mit .logo-mit .color {
+  fill: #fff;
 }
-
-.no-flexbox .footer-info-institute .link-mit-home {
-  padding-top: 1.5em
+.wrap-outer-footer-institute .about-mit {
+  color: #dedede;
+  margin-right: 4%;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
-
-.no-flexbox .footer-main.flex-container {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main:after {
-  clear: both;
-  content: '';
-  display: table
-}
-
-.no-flexbox .footer-main .identity {
-  position: relative;
-  width: 100%
-}
-
-.no-flexbox .footer-main .identity .logo-mit-lib {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main .identity .social {
-  bottom: 0;
-  display: block;
-  right: 22px;
-  position: absolute
-}
-
-.no-flexbox .footer-main .links-primary {
-  display: block;
-  margin-top: 0;
-  margin-left: 0;
-  left: 202px;
-  position: absolute;
-  top: 79px;
-  width: 100%
-}
-
-.no-flexbox .footer-main .links-primary span {
-  display: block;
-  float: left;
-  position: relative
-}
-
-.no-flexbox.flexboxlegacy .footer-main {
-  overflow-x: hidden
-}
-
-.lte-ie9.no-flexbox .footer-main .identity {
-  width: 100%
+.wrap-outer-footer-institute .license {
+  margin-left: auto;
+  margin-top: 1rem;
+  color: #dedede;
 }
 
 /* 3. no-flexbox fallbacks */
@@ -1278,7 +1207,7 @@ svg {
 }
 
 .header-main, 
-.footer-main-wrap {
+.layout-band {
   max-width: 1170px; /* matches .container */
   width: 100%;
   margin: 0 auto;

--- a/libanswers/custom-header.html
+++ b/libanswers/custom-header.html
@@ -98,7 +98,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
             <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>

--- a/libcal/custom-footer.html
+++ b/libcal/custom-footer.html
@@ -1,121 +1,77 @@
-<footer class="footer-main-wrap">
-	<div class="footer-main flex-container">
-		<div class="links-all flex-container">
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/search">Search</a></h4>
-				<a href="https://libraries.mit.edu/quicksearch" class="link-sub">Quick search</a>
-				<a href="https://libraries.mit.edu/barton" class="link-sub">Barton catalog</a>
-				<a href="https://libraries.mit.edu/vera" class="link-sub">Vera: E-journals &amp; databases</a>
-				<a href="https://libraries.mit.edu/worldcat" class="link-sub">WorldCat</a>
-				<a href="https://libraries.mit.edu/barton-reserves" class="link-sub">Course reserves</a>
-				<a href="https://libraries.mit.edu/site-search" class="link-sub">Site search</a>
-				<a href="https://libraries.mit.edu/search" class="link-sub">More search options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/hours">Hours &amp; locations</a></h4>
-				<a href="https://libraries.mit.edu/hours" class="link-sub">Hours</a>
-				<a href="https://libraries.mit.edu/locations" class="link-sub">Map of locations</a>
-				<a href="https://libraries.mit.edu/study" class="link-sub">Study spaces</a>
-				<a href="https://libraries.mit.edu/exhibits" class="link-sub">Exhibits &amp; galleries</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/borrow">Borrow &amp; request</a></h4>
-				<a href="https://libraries.mit.edu/barton-account" class="link-sub">Your Account</a>
-				<a href="https://libraries.mit.edu/getit" class="link-sub">Get it: options for getting books &amp; articles</a>
-				<a href="https://libraries.mit.edu/circ" class="link-sub">Circulation FAQ</a>
-				<a href="https://libraries.mit.edu/reserves" class="link-sub">Reserves &amp; TIP FAQ</a>
-				<a href="https://libraries.mit.edu/otherlibraries" class="link-sub">Visit non-MIT libraries</a>
-				<a href="https://libraries.mit.edu/borrow" class="link-sub">More borrow &amp; request options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/research-support">Research support</a></h4>
-				<a href="https://libraries.mit.edu/ask" class="link-sub">Ask us</a>
-				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
-				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
-				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
-				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/about">About us</a></h4>
-				<a href="https://libraries.mit.edu/contact" class="link-sub">Contact us</a>
-				<a href="https://libraries.mit.edu/news" class="link-sub">News</a>
-				<a href="https://libraries.mit.edu/events" class="link-sub">Classes &amp; events</a>
-				<a href="https://libraries.mit.edu/use-policies" class="link-sub">Use policy</a>
-				<a href="https://libraries.mit.edu/site-search/" class="link-sub">Services A-Z</a>
-				<a href="https://libraries.mit.edu/about" class="link-sub">More about us</a>
-			</div>
-		</div><!-- end div.links-all -->
-		
-		<div class="identity flex-container">
-			<a href="https://libraries.mit.edu/" class="logo-mit-lib" alt="MIT Libraries Logo">
-				<svg xmlns="http://www.w3.org/2000/svg" width="193.9" height="77.55" viewBox="0 0 193.9 77.55"><title>MIT Libraries logo</title><path d="M5.3,5.55H17.2L21.55,21.2q0.25,0.85.58,2.22T22.8,26.1q0.4,1.55.8,3.25h0.1q0.35-1.7.75-3.25,0.3-1.3.65-2.67t0.6-2.22L30.1,5.55h12V41.3H34V21.58q0-1.17,0-2.37,0-1.4.1-3.05H34q-0.4,1.55-.7,2.85t-0.53,2.22q-0.28,1.08-.42,1.58L27.25,41.3h-7.3l-5.1-18.45q-0.15-.5-0.45-1.6T13.85,19q-0.3-1.3-.65-2.85H13.1q0,1.65,0,3.05,0,1.2.08,2.4t0,1.75v18h-8V5.55Zm40,0h8.85V41.3H45.32V5.55ZM67.4,13H57V5.55H86.75V13H76.25V41.3H67.4V13ZM5.3,46.55h8.85V74.8H30.82v7.5H5.3V46.55Zm28.7,0h8.15v6.6H34v-6.6ZM34,56.7h8.15V82.3H34V56.7ZM61,83.1a9.84,9.84,0,0,1-4.55-1,7.87,7.87,0,0,1-3.2-3h-0.1V82.3h-7.8V46.55h8.15v13h0.15A9.45,9.45,0,0,1,56.55,57a8.63,8.63,0,0,1,4.37-1,9.89,9.89,0,0,1,4.53,1,10.16,10.16,0,0,1,3.45,2.85,13.44,13.44,0,0,1,2.2,4.3,17.91,17.91,0,0,1,.78,5.38,19.49,19.49,0,0,1-.78,5.72,12.5,12.5,0,0,1-2.2,4.28,9.47,9.47,0,0,1-3.45,2.67A10.66,10.66,0,0,1,61,83.1Zm-2.3-6.45a4.14,4.14,0,0,0,3.67-1.92,9.45,9.45,0,0,0,1.28-5.27,9.74,9.74,0,0,0-1.28-5.3,4.19,4.19,0,0,0-3.77-2,4.44,4.44,0,0,0-4,2.1,9.66,9.66,0,0,0-1.33,5.25,8.53,8.53,0,0,0,1.45,5.17A4.69,4.69,0,0,0,58.67,76.65ZM73.81,56.7h7.8v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27Q82,66.6,82,70.8V82.3H73.81V56.7ZM99.76,83a12,12,0,0,1-3.53-.5A7.54,7.54,0,0,1,93.46,81a7,7,0,0,1-1.8-2.45A8.11,8.11,0,0,1,91,75.15a7.29,7.29,0,0,1,.78-3.52,6.67,6.67,0,0,1,2.12-2.35A10.55,10.55,0,0,1,97,67.85a25.72,25.72,0,0,1,3.77-.75,24.65,24.65,0,0,0,5-1,1.92,1.92,0,0,0,1.45-1.85,2.57,2.57,0,0,0-.83-2,3.92,3.92,0,0,0-2.67-.75,4.45,4.45,0,0,0-3,.85,3.67,3.67,0,0,0-1.2,2.45h-7.5a8.46,8.46,0,0,1,.8-3.4,8.17,8.17,0,0,1,2.17-2.8,10.56,10.56,0,0,1,3.58-1.9,16.34,16.34,0,0,1,5-.7,19.62,19.62,0,0,1,4.9.52,9.73,9.73,0,0,1,3.4,1.58,7.29,7.29,0,0,1,2.45,3,10.63,10.63,0,0,1,.8,4.25V78.3a13,13,0,0,0,.17,2.42,1.78,1.78,0,0,0,.73,1.23V82.3h-7.9a3.37,3.37,0,0,1-.5-1.12,14.64,14.64,0,0,1-.35-1.72h-0.1A8.47,8.47,0,0,1,104.44,82,9.92,9.92,0,0,1,99.76,83Zm2.6-5.2a5.45,5.45,0,0,0,3.73-1.25,4.23,4.23,0,0,0,1.42-3.35v-3a11.85,11.85,0,0,1-1.87.73q-1.08.33-2.33,0.63a10.45,10.45,0,0,0-3.4,1.27,2.47,2.47,0,0,0-1.05,2.17,2.42,2.42,0,0,0,1,2.2A4.5,4.5,0,0,0,102.36,77.75Zm15.87-21H126v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.23,1.83-2.23,6V82.3h-8.15V56.7Zm18.94-10.15h8.15v6.6h-8.15v-6.6Zm0,10.15h8.15V82.3h-8.15V56.7Zm24,26.35a15.16,15.16,0,0,1-5.7-1,12.12,12.12,0,0,1-4.3-2.85,12.66,12.66,0,0,1-2.7-4.33,15.06,15.06,0,0,1-1-5.4,14.72,14.72,0,0,1,1-5.33,12.71,12.71,0,0,1,2.7-4.3A12.46,12.46,0,0,1,155.3,57a14.58,14.58,0,0,1,10.28-.17,12.28,12.28,0,0,1,3.83,2.35,12.76,12.76,0,0,1,3.42,5.33,20.72,20.72,0,0,1,1.08,7.13H155.5a7.52,7.52,0,0,0,1.8,4.1,5.14,5.14,0,0,0,4,1.5,4.81,4.81,0,0,0,2.65-.68,4.3,4.3,0,0,0,1.6-1.87h8a9.47,9.47,0,0,1-1.5,3.33,10.65,10.65,0,0,1-2.8,2.73,12.12,12.12,0,0,1-3.58,1.75A15.22,15.22,0,0,1,161.15,83Zm4.5-16.3a6,6,0,0,0-1.55-3.65,4.39,4.39,0,0,0-3.3-1.35,4.66,4.66,0,0,0-3.6,1.35,7,7,0,0,0-1.65,3.65h10.1Zm21.9,16.35q-5.65,0-8.95-2.42A8.35,8.35,0,0,1,175.1,74h7.7a4.15,4.15,0,0,0,1.45,2.85,5.09,5.09,0,0,0,3.25,1,5.63,5.63,0,0,0,2.92-.65,2.09,2.09,0,0,0,1.08-1.9,1.82,1.82,0,0,0-.55-1.37,4.08,4.08,0,0,0-1.45-.85,10.92,10.92,0,0,0-2.08-.5q-1.17-.17-2.42-0.42-1.65-.3-3.3-0.72a10.14,10.14,0,0,1-3-1.28,6.33,6.33,0,0,1-2.12-2.27,7.45,7.45,0,0,1-.8-3.68,7.1,7.1,0,0,1,.87-3.55A7.64,7.64,0,0,1,179,58a11.18,11.18,0,0,1,3.53-1.55,17,17,0,0,1,4.28-.52q5.45,0,8.35,2.2a8,8,0,0,1,3.2,6h-7.5a3,3,0,0,0-1.33-2.37,5.48,5.48,0,0,0-2.78-.62,5.1,5.1,0,0,0-2.52.58,1.9,1.9,0,0,0-1,1.78,1.33,1.33,0,0,0,.5,1.1,4.21,4.21,0,0,0,1.35.67,14.86,14.86,0,0,0,2,.48l2.33,0.4q1.7,0.3,3.42.73A10.59,10.59,0,0,1,196,68.2a7.05,7.05,0,0,1,2.32,2.42,7.75,7.75,0,0,1,.9,4A7.35,7.35,0,0,1,195.9,81a11.75,11.75,0,0,1-3.7,1.6A18.75,18.75,0,0,1,187.54,83.1Z" transform="translate(-5.3 -5.55)" /></svg>
-				<span class="sr">MIT Libraries</span>
-			</a><!-- End MIT Libraries Logo -->
-			
-			<div class="social flex-container">
-				<p class="text-find-us">Find us on</p>
-					<a href="https://twitter.com/mitlibraries" title="Twitter">
-						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
-						<span class="sr">Twitter</span>
-					</a><!-- End Twitter -->
-					
-					<a href="https://libraries.mit.edu/facebook" title="Facebook">
-						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
-						<span class="sr">Facebook</span>
-					</a><!-- End Facebook -->
-					
-					<a href="https://instagram.com/mitlibraries/" title="Instagram">
-						<svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2
-	c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1
-	c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4
-	C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0
-	c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4
-	c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z
-	 M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z
-	 M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
-	c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
-						<span class="sr">Instagram</span>
+<footer>
+<div class="wrap-outer-footer layout-band">
+    <div class="wrap-footer footer-slim">
+        <div class="footer-main" aria-label="MIT Libraries footer">
+            <div class="identity">
+                <div class="wrap-logo-lib">
+                    <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
+											<svg xmlns="http://www.w3.org/2000/svg" width="194.05" height="77.65" viewBox="0 0 194.05 77.65"><title>MIT Libraries Logo</title><path d="M0,0H11.9l4.35,15.65q0.25,0.85.58,2.22t0.67,2.68q0.4,1.55.8,3.25h0.1q0.35-1.7.75-3.25,0.3-1.3.65-2.67t0.6-2.22L24.8,0h12V35.75H28.7V13.66q0-1.4.1-3.05H28.7q-0.4,1.55-.7,2.85t-0.53,2.22q-0.28,1.08-.42,1.58l-5.1,18.49h-7.3L9.55,17.3Q9.4,16.8,9.1,15.7T8.55,13.45q-0.3-1.3-.65-2.85H7.8v3.05q0,1.2.08,2.4a9.26,9.26,0,0,1,0,1.75v18h-8V0H0ZM40,0h8.85V35.75H40V0h0ZM62.1,7.45H51.7V0H81.45V7.45H70.95v28.3H62.1V7.45ZM0,41H8.85V69.25H25.52v7.5H0V41Zm28.7,0h8.15v6.6H28.7V41Zm0,10.15h8.15v25.6H28.7V51.15Zm27,26.4a9.84,9.84,0,0,1-4.55-1,7.87,7.87,0,0,1-3.2-3h-0.1v3.2h-7.8V41H48.2V54h0.15a9.45,9.45,0,0,1,2.9-2.55,8.63,8.63,0,0,1,4.37-1,9.89,9.89,0,0,1,4.53,1A10.16,10.16,0,0,1,63.6,54.3a13.44,13.44,0,0,1,2.2,4.3A17.91,17.91,0,0,1,66.58,64a19.49,19.49,0,0,1-.78,5.72A12.5,12.5,0,0,1,63.6,74a9.47,9.47,0,0,1-3.45,2.67A10.66,10.66,0,0,1,55.7,77.55ZM53.4,71.1a4.14,4.14,0,0,0,3.67-1.92,9.45,9.45,0,0,0,1.28-5.27,9.74,9.74,0,0,0-1.28-5.3,4.19,4.19,0,0,0-3.77-2,4.44,4.44,0,0,0-4,2.1A9.66,9.66,0,0,0,48,64a8.53,8.53,0,0,0,1.45,5.17,4.69,4.69,0,0,0,4,2h0Zm15.11-20h7.8v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.16,1.78-2.16,6v11.5H68.51V51.15Zm26,26.3a12,12,0,0,1-3.53-.5,7.54,7.54,0,0,1-2.77-1.5A7,7,0,0,1,86.36,73a8.11,8.11,0,0,1-.66-3.4,7.29,7.29,0,0,1,.78-3.52,6.67,6.67,0,0,1,2.12-2.35,10.55,10.55,0,0,1,3.1-1.43,25.72,25.72,0,0,1,3.77-.75,24.65,24.65,0,0,0,5-1,1.92,1.92,0,0,0,1.45-1.85,2.57,2.57,0,0,0-.83-2A3.92,3.92,0,0,0,98.42,56a4.45,4.45,0,0,0-3,.85,3.67,3.67,0,0,0-1.2,2.45h-7.5a8.46,8.46,0,0,1,.8-3.4,8.17,8.17,0,0,1,2.17-2.8,10.56,10.56,0,0,1,3.58-1.9,16.34,16.34,0,0,1,5-.7,19.62,19.62,0,0,1,4.9.52,9.73,9.73,0,0,1,3.4,1.58,7.29,7.29,0,0,1,2.45,3,10.63,10.63,0,0,1,.8,4.25V72.75a13,13,0,0,0,.17,2.42,1.78,1.78,0,0,0,.73,1.23v0.35h-7.9a3.37,3.37,0,0,1-.5-1.12,14.64,14.64,0,0,1-.35-1.72h-0.1a8.47,8.47,0,0,1-2.73,2.54A9.92,9.92,0,0,1,94.46,77.45Zm2.6-5.2A5.45,5.45,0,0,0,100.79,71a4.23,4.23,0,0,0,1.42-3.35v-3a11.85,11.85,0,0,1-1.87.73Q99.26,65.71,98,66a10.45,10.45,0,0,0-3.4,1.27,2.47,2.47,0,0,0-1.05,2.17,2.42,2.42,0,0,0,1,2.2,4.5,4.5,0,0,0,2.5.55v0.05Zm15.87-21h7.77v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.23,1.83-2.23,6V76.75h-8.15V51.15ZM131.87,41.1H140v6.6h-8.15V41.1Zm0,10.15H140v25.5h-8.15V51.25Zm24,26.35a15.16,15.16,0,0,1-5.7-1,12.12,12.12,0,0,1-4.3-2.85,12.66,12.66,0,0,1-2.7-4.33,15.06,15.06,0,0,1-1-5.4,14.72,14.72,0,0,1,1-5.33,12.71,12.71,0,0,1,2.7-4.3A12.46,12.46,0,0,1,150,51.45a14.58,14.58,0,0,1,10.28-.17,12.28,12.28,0,0,1,3.83,2.35A12.76,12.76,0,0,1,167.53,59a20.72,20.72,0,0,1,1.08,7.13H150.2a7.52,7.52,0,0,0,1.8,4.1,5.14,5.14,0,0,0,4,1.5,4.81,4.81,0,0,0,2.65-.68,4.3,4.3,0,0,0,1.6-1.87h8a9.47,9.47,0,0,1-1.5,3.33,10.65,10.65,0,0,1-2.8,2.73A12.12,12.12,0,0,1,160.37,77a15.22,15.22,0,0,1-4.52.5Zm4.5-16.3a6,6,0,0,0-1.55-3.65,4.39,4.39,0,0,0-3.3-1.35,4.66,4.66,0,0,0-3.6,1.35,7,7,0,0,0-1.65,3.65h10.1Zm21.9,16.35q-5.65,0-8.95-2.42a8.35,8.35,0,0,1-3.52-6.78h7.7a4.15,4.15,0,0,0,1.45,2.85,5.09,5.09,0,0,0,3.25,1,5.63,5.63,0,0,0,2.92-.65,2.09,2.09,0,0,0,1.08-1.9,1.82,1.82,0,0,0-.55-1.37,4.08,4.08,0,0,0-1.45-.85,10.92,10.92,0,0,0-2.08-.5q-1.17-.17-2.42-0.42-1.65-.3-3.3-0.72a10.14,10.14,0,0,1-3-1.28,6.33,6.33,0,0,1-2.12-2.27,7.45,7.45,0,0,1-.8-3.68,7.1,7.1,0,0,1,.87-3.55,7.64,7.64,0,0,1,2.35-2.66,11.18,11.18,0,0,1,3.53-1.55,17,17,0,0,1,4.28-.52q5.45,0,8.35,2.2a8,8,0,0,1,3.2,6h-7.5a3,3,0,0,0-1.33-2.37,5.48,5.48,0,0,0-2.78-.62,5.1,5.1,0,0,0-2.52.58,1.9,1.9,0,0,0-1,1.78,1.33,1.33,0,0,0,.5,1.1,4.21,4.21,0,0,0,1.35.67,14.86,14.86,0,0,0,2,.48l2.33,0.4q1.7,0.3,3.42.73a10.59,10.59,0,0,1,3.17,1.32A7.05,7.05,0,0,1,193,65.07a7.75,7.75,0,0,1,.9,4,7.35,7.35,0,0,1-3.32,6.38,11.75,11.75,0,0,1-3.7,1.6,18.75,18.75,0,0,1-4.66.5Z" transform="translate(0.12)" fill="#fff"/></svg>
+                    </a>
+                </div>
+                <div class="wrap-social">
+                    <p class="text-find-us">Find us on</p>
+                    <a href="//twitter.com/mitlibraries" title="Twitter">
+                        <svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black"></path></g></svg>
+                        <span class="sr">Twitter</span>
+                    </a><!-- End Twitter -->
+                    
+                    <a href="https://www.facebook.com/mitlib" title="Facebook">
+                        <svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black"></path></g></svg>
+                        <span class="sr">Facebook</span>
+                    </a><!-- End Facebook -->
+                    
+                    <a href="//instagram.com/mitlibraries/" title="Instagram">
+                        <svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1 c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4 C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0 c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4 c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"></path></svg>
+                        <span class="sr">Instagram</span>
+                    </a><!-- End Instagram -->
+                    
+                    <a href="//www.youtube.com/user/MITLibraries" title="YouTube">
+                        <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+                        <span class="sr">YouTube</span>
+                    </a><!-- End YouTube -->
 
-					</a><!-- End Instagram -->
-					
-					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
-						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
-						<span class="sr">YouTube</span>
-					</a><!-- End YouTube -->
-
-					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
-						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
-						<span class="sr">RSS</span>
-					</a><!-- End RSS -->
-
-			</div><!-- end div.social -->
-			
-			<div class="links-primary flex-container">
-				<span><a href="https://libraries.mit.edu/faculty" class="link-sub">Faculty</a></span>
-				<span><a href="https://libraries.mit.edu/alumni" class="link-sub">Alumni</a></span>
-				<span><a href="https://libraries.mit.edu/visitors" class="link-sub">Visitors</a></span>
-				<span><a href="https://libraries.mit.edu/giving" class="link-sub">Giving</a></span>
-				<span><a href="https://libraries.mit.edu/disabilities" class="link-sub">Persons with disabilities</a></span>
-			</div><!-- End div.links-primary -->
-			
-		</div><!-- End div.identity -->
-	</div>
-	
-	<div class="footer-info-institute">
-		<a class="link-logo-mit" href="http://www.mit.edu">
-			<span class="sr">MIT</span>
-			<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
-		</a><!-- End MIT Logo -->
-		
-		<div class="about-mit">
-			<span>MASSACHUSETTS INSTITUTE OF TECHNOLOGY </span>
-			<span>77 MASSACHUSETTS AVENUE </span>
-			<span>CAMBRIDGE MA 02139-4307</span>
-		</div><!-- End div.about-mit -->
-		
-		<div class="license">Licensed under the <a href="http://creativecommons.org/licenses/by-nc/2.0/" class="license-cc">Creative Commons Attribution Non-Commercial License</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
-		</div><!-- End footer.footer-info-institure -->
-	</div>
+                    <a href="//libguides.mit.edu/mit-feeds" title="RSS">
+                        <svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black"></path></g></svg>
+                        <span class="sr">RSS</span>
+                    </a><!-- End RSS -->
+                </div><!-- end .social -->
+                <div class="wrap-middle">
+                    <div class="wrap-sitemap">
+                        <nav class="sitemap-libraries-abbrev" aria-label="MIT Libraries site menu">
+                            <h2 class="sr">MIT Libraries navigation</h2>
+                            <a class="item" href="https://libraries.mit.edu/search">Search</a>
+                            <a class="item" href="https://libraries.mit.edu/hours">Hours &amp; locations</a>
+                            <a class="item" href="https://libraries.mit.edu/borrow">Borrow &amp; request</a>
+                            <a class="item" href="https://libraries.mit.edu/research-support">Research support</a>
+                            <a class="item" href="https://libraries.mit.edu/about">About us</a>
+                        </nav>
+                    </div><!-- end .links-all -->
+                    <div class="wrap-policies">
+                        <nav aria-label="MIT Libraries policy menu">
+                            <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+                            <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
+                            <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
+                        </nav>
+                    </div>
+                </div>
+            </div><!-- end .identity -->
+        </div>
+    </div>
+</div>
+<div class="wrap-outer-footer-institute layout-band">
+    <div class="wrap-footer-institute">
+        <div class="footer-info-institute">
+            <a class="link-logo-mit" href="https://www.mit.edu">
+                <span class="sr">MIT</span>
+                <svg version="1.1" xmlns="https://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
+            </a>
+            <div class="about-mit">
+                <span class="item">Massachusetts Institute of Technology</span>
+            </div>
+            <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
+            </div><!-- end .footer-info-institute -->
+        </div>
+    </div>
+</div>
 </footer>
 <script src="//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88"></script>

--- a/libcal/custom-head.html
+++ b/libcal/custom-head.html
@@ -801,407 +801,336 @@ svg {
 }
 
 /* 2. Footer */
-.footer-main {
-  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+.wrap-footer {
+  font-size: 12px;
+}
+.wrap-footer .wrap-policies, .wrap-footer.footer-slim .sitemap-libraries-abbrev a {
+  padding-left: 0;
+}
+.wrap-footer .wrap-policies li, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li,
+.wrap-footer .wrap-policies .item,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item {
+  display: inline-block;
+  padding-right: 1rem;
+}
+.wrap-footer .wrap-policies li:after, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li:after,
+.wrap-footer .wrap-policies .item:after,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item:after {
+  content: ' | ';
+  margin-left: 1rem;
+}
+.wrap-footer .wrap-policies li:last-child:after, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li:last-child:after,
+.wrap-footer .wrap-policies .item:last-child:after,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item:last-child:after {
+  content: '';
+}
+.layout-band:after {
+  content: '';
+  display: table;
   clear: both;
-  width: 100%
+}
+.wrap-footer,
+.wrap-footer-institute {
+  max-width: 114rem;
+  margin: 0 auto;
+  padding: 10px 4%;
+}
+.wrap-footer:after,
+.wrap-footer-institute:after {
+  content: '';
+  display: table;
+  clear: both;
+}
+.wrap-outer-footer {
+  background-color: #000;
+  color: #fff;
+  font-size: 1.2em;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-main {
-    padding: 2em 1.375em
-  }
+.wrap-footer {
+  padding: 3.5rem 4%;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main {
-    width: 100%
-  }
+.wrap-footer .wrap-sitemap .menu-sub {
+  display: none;
 }
-
-.footer-main a {
-  color: #fff
+.wrap-footer .identity {
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
-
-.footer-main .identity {
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 2em 0 0
+.wrap-footer .wrap-logo-lib {
+  display: inline-block;
+  vertical-align: bottom;
+  margin: 0 20px 20px 0;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main .identity {
-    -webkit-box-align: end;
-    -webkit-align-items: flex-end;
-    -ms-flex-align: end;
-    align-items: flex-end;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-    width: 100%
-  }
+.wrap-footer .wrap-social {
+  display: inline-block;
+  vertical-align: bottom;
+  margin-bottom: 20px;
 }
-
-.footer-main .links-all {
-  display: none
+.wrap-footer .wrap-policies {
+  width: 100%;
+  border-top: 1px solid #595959;
+  padding-top: 2rem;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all {
+.wrap-footer .wrap-policies span {
+  display: inline-block;
+  margin: 1rem 1.5rem 1rem 0;
+}
+.wrap-footer .wrap-policies span.item {
+  margin-right: 0;
+}
+.wrap-footer .wrap-policies span:after {
+  content: '';
+}
+.wrap-footer .wrap-social .text-find-us {
+  display: none;
+}
+@media (min-width: 768px) {
+  .wrap-footer .wrap-sitemap {
     display: -webkit-box;
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    width: 100%
-  }
-}
-
-.footer-main .links-all h4 {
-  font-size: 1.125em;
-  font-weight: 400;
-  padding-bottom: 1em
-}
-
-.footer-main .links-all .flex-item {
-  margin-right: 1.75em
-}
-
-.footer-main .links-all .link-sub {
-  display: block;
-  font-size: .75em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all .link-sub {
-    font-size: .75em;
-    font-weight: 300
-  }
-  .footer-main .links-all .link-sub:not(:last-of-type) {
-    padding-bottom: 1em
-  }
-}
-
-.footer-main .links-primary {
-  border-top: 1px solid #808285;
-  border-bottom: 1px solid #808285;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  font-size: .8125em;
-  margin-top: 2em;
-  padding: 2rem 1.375rem;
-  width: 100%
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary {
-    border-top: none;
-    border-bottom: none;
-    font-size: .875em;
-    margin-top: -22.4px;
-    margin-top: -1.4rem;
-    margin-left: 184px;
-    margin-left: 11.5rem;
-    padding: 0;
-    z-index: 3000
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary {
-    margin-top: 24px;
-    margin-top: 1.5rem;
-    margin-left: 0;
-    margin-left: 0
-  }
-}
-
-.footer-main .links-primary span {
-  display: block;
-  width: 50%
-}
-
-.footer-main .links-primary span:not(:last-of-type) {
-  margin-bottom: 1.5em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary span {
-    font-weight: 300;
-    padding-left: 1em;
-    width: auto
-  }
-  .footer-main .links-primary span:not(:last-of-type):after {
-    color: #dedede;
-    content: '|';
-    display: inline-block;
-    margin-left: 1em
-  }
-}
-
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary span:first-of-type {
-    padding-left: 0
-  }
-}
-
-.footer-main .logo-mit-lib {
-  display: block;
-  fill: #fff;
-  padding-left: 1.375em;
-  width: 10.3125em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .logo-mit-lib {
-    padding-left: 0;
-    max-width: 9.5em;
-    width: 9.5em
-  }
-}
-
-.footer-main .logo-mit-lib svg {
-  max-height: 4em;
-  max-width: 9.5em
-}
-
-.footer-main .text-find-us {
-  color: #fff;
-  display: none;
-  font-size: .625em;
-  font-weight: 700;
-  text-transform: uppercase;
-  min-width: 7em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .text-find-us {
-    display: block
-  }
-}
-
-.footer-main .social {
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding-left: 1.375em;
-  width: auto
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    margin-bottom: -.8em;
-    z-index: 4000
-  }
-}
-
-.footer-main .social a {
-  width: 33%
-}
-
-.footer-main .social a:hover {
-  text-decoration: none
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social a {
-    width: 20%
-  }
-  .footer-main .social a:not(:last-of-type) {
-    margin-right: .5em
-  }
-}
-
-.footer-main .social [class*=icon-social] {
-  background: #fff;
-  -webkit-border-radius: 50%;
-  border-radius: 50%;
-  height: 1.5em;
-  padding: .2em;
-  width: 1.5em
-}
-
-.footer-main .social [class*=icon-social] path {
-  fill: #000
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social [class*=icon-social] {
-    height: 2em;
-    padding: .2em;
-    width: 2em
-  }
-}
-
-.footer-info-institute {
-  -webkit-box-align: baseline;
-  -webkit-align-items: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-  background: #333;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 1.5em 1em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute {
     -webkit-box-orient: horizontal;
     -webkit-box-direction: normal;
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row
+        -ms-flex-direction: row;
+            flex-direction: row;
+  }
+  .wrap-footer .wrap-sitemap .col {
+    margin-right: 3%;
+  }
+  .wrap-footer .wrap-sitemap .col:last-child {
+    margin-right: 0;
+  }
+  .wrap-footer .wrap-sitemap .menu-sub {
+    display: block;
+  }
+  .wrap-footer .identity {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
+    margin: 4% 0 0 0;
+  }
+  .wrap-footer .wrap-logo-lib,
+  .wrap-footer .wrap-policies,
+  .wrap-footer .wrap-social {
+    -ms-flex-item-align: end;
+        align-self: flex-end;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .wrap-footer .wrap-logo-lib {
+    -webkit-box-ordinal-group: 2;
+        -ms-flex-order: 1;
+            order: 1;
+    margin-right: 4%;
+  }
+  .wrap-footer .wrap-policies {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+    padding: auto;
+    border-top: none;
+    width: auto;
+  }
+  .wrap-footer .wrap-policies span {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .wrap-footer .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+    margin-left: auto;
+  }
+}
+@media (min-width: 1024px) {
+  .wrap-footer .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+  }
+  .wrap-footer .wrap-policies {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
   }
 }
 
-.footer-info-institute .about-mit {
-  font-size: .625em;
-  margin-bottom: 2em
+.wrap-footer.footer-slim {
+  padding: 1.5rem 4%;
 }
-
-.footer-info-institute .about-mit span {
-  color: #eee;
-  text-transform: uppercase
+.wrap-footer.footer-slim .wrap-middle {
+  -webkit-box-ordinal-group: 3;
+      -ms-flex-order: 2;
+          order: 2;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: start;
+      -ms-flex-align: start;
+          align-items: flex-start;
 }
-
-.footer-info-institute .about-mit span:first-of-type {
-  font-weight: 700
+.wrap-footer.footer-slim .wrap-middle .wrap-policies {
+  -ms-flex-item-align: start;
+      align-self: flex-start;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute .about-mit span {
-    color: #ededed
+.wrap-footer.footer-slim .wrap-middle .wrap-sitemap {
+  display: inline-block;
+  margin-bottom: 2rem;
+}
+.wrap-footer.footer-slim .wrap-middle .wrap-sitemap .item {
+  display: block;
+  margin-right: 10px;
+  margin-bottom: 5px;
+}
+@media (min-width: 768px) {
+  .wrap-footer.footer-slim .wrap-middle {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
   }
-  .footer-info-institute .about-mit span:not(:last-of-type):after {
-    content: '|';
-    font-weight: 400
+  .wrap-footer.footer-slim .wrap-middle .wrap-policies {
+    margin-left: 2%;
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+  }
+  .wrap-footer.footer-slim .wrap-middle .wrap-sitemap {
+    display: inline-block;
+    margin-left: 2%;
+    margin-bottom: auto;
+    -webkit-box-ordinal-group: 2;
+        -ms-flex-order: 1;
+            order: 1;
+  }
+  .wrap-footer.footer-slim .wrap-middle .wrap-sitemap .item {
+    display: inline-block;
+    margin-bottom: auto;
+  }
+  .wrap-footer.footer-slim .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
   }
 }
 
-.footer-info-institute .license {
-  color: #ededed;
-  font-size: .6875em;
-  width: 100%
+.wrap-footer-institute {
+  padding: 20px 4%;
 }
 
-.footer-info-institute .license a {
-  color: #ededed
+.wrap-content li {
+  margin-bottom: .5em;
+}
+.wrap-content .title-page {
+  margin-bottom: 1rem;
+  padding: .5rem 0 1rem 0;
+  font-weight: 600;
 }
 
-.footer-info-institute .link-mit-home {
-  display: block
+.wrap-footer {
+  background: #000 url("https://libraries.mit.edu/images/vi-shape7-tp.png") no-repeat 10%;
+}
+.wrap-footer a {
+  color: #fff;
+  text-decoration: none;
+}
+.wrap-footer a:hover, .wrap-footer a:active, .wrap-footer a:focus {
+  text-decoration: underline;
+  color: #fff;
+}
+.wrap-footer .title {
+  margin-bottom: .8rem;
+}
+.wrap-footer .wrap-list .link-sub {
+  display: list-item;
+  list-style-type: none;
+  margin-bottom: .65rem;
+  font-weight: 300;
+}
+.wrap-footer .logo-mit-lib {
+  fill: #fff;
+}
+.wrap-footer .logo-mit-lib svg {
+  max-height: 60px;
+  max-width: 100%;
+  vertical-align: baseline;
+}
+.wrap-footer .wrap-policies {
+  font-size: 1.4em;
+}
+.wrap-footer .wrap-social p, .wrap-footer .wrap-social a {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: .5rem;
+  margin-bottom: 0;
+  text-transform: uppercase;
+  font-size: 1.2em;
+}
+.wrap-footer .wrap-social svg {
+  height: 2em;
+  width: 2em;
+  border-radius: 50%;
+  padding: 0.2em;
+  background: #fff none repeat scroll 0 0;
+}
+.wrap-footer .wrap-social svg path {
+  fill: #333;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-info-institute .link-mit-home {
-    margin: 0 1em 1.5em 0
-  }
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a {
+  font-size: 1.4em;
 }
 
-.footer-info-institute .logo-mit {
-  fill: #bbb9b8;
-  width: 3.375em
+.wrap-outer-footer-institute {
+  background-color: #333;
+  font-size: 12px;
+  color: #dedede;
 }
-
-.footer-info-institute .logo-mit .color {
-  fill: #ededed
+.wrap-outer-footer-institute .footer-info-institute {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
 }
-
-.no-flexbox .footer-info-institute {
-  display: block
+.wrap-outer-footer-institute a {
+  color: #fff;
 }
-
-.no-flexbox .footer-info-institute:after {
-  clear: both;
-  content: '';
-  display: table
+.wrap-outer-footer-institute a:hover, .wrap-outer-footer-institute a:active, .wrap-outer-footer-institute a:focus {
+  color: #fff;
 }
-
-.no-flexbox .footer-info-institute>a,
-.no-flexbox .footer-info-institute>div {
-  float: left
+.wrap-outer-footer-institute .link-logo-mit .logo-mit {
+  fill: #ccc;
 }
-
-.no-flexbox .footer-info-institute .about-mit {
-  padding-top: 4em
+.wrap-outer-footer-institute .link-logo-mit .logo-mit .color {
+  fill: #fff;
 }
-
-.no-flexbox .footer-info-institute .link-mit-home {
-  padding-top: 1.5em
+.wrap-outer-footer-institute .about-mit {
+  color: #dedede;
+  margin-right: 4%;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
-
-.no-flexbox .footer-main.flex-container {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main:after {
-  clear: both;
-  content: '';
-  display: table
-}
-
-.no-flexbox .footer-main .identity {
-  position: relative;
-  width: 100%
-}
-
-.no-flexbox .footer-main .identity .logo-mit-lib {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main .identity .social {
-  bottom: 0;
-  display: block;
-  right: 22px;
-  position: absolute
-}
-
-.no-flexbox .footer-main .links-primary {
-  display: block;
-  margin-top: 0;
-  margin-left: 0;
-  left: 202px;
-  position: absolute;
-  top: 79px;
-  width: 100%
-}
-
-.no-flexbox .footer-main .links-primary span {
-  display: block;
-  float: left;
-  position: relative
-}
-
-.no-flexbox.flexboxlegacy .footer-main {
-  overflow-x: hidden
-}
-
-.lte-ie9.no-flexbox .footer-main .identity {
-  width: 100%
+.wrap-outer-footer-institute .license {
+  margin-left: auto;
+  margin-top: 1rem;
+  color: #dedede;
 }
 
 /* 3. no-flexbox fallbacks */
@@ -1277,7 +1206,7 @@ svg {
 }
 
 .header-main, 
-.footer-main-wrap {
+.layout-band {
   max-width: 1170px; /* matches .container */
   width: 100%;
   margin: 0 auto;

--- a/libcal/custom-header.html
+++ b/libcal/custom-header.html
@@ -98,7 +98,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
             <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>

--- a/libguides/custom-footer.html
+++ b/libguides/custom-footer.html
@@ -1,121 +1,77 @@
-<footer class="footer-main-wrap">
-	<div class="footer-main flex-container">
-		<div class="links-all flex-container">
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/search">Search</a></h4>
-				<a href="https://libraries.mit.edu/quicksearch" class="link-sub">Quick search</a>
-				<a href="https://libraries.mit.edu/barton" class="link-sub">Barton catalog</a>
-				<a href="https://libraries.mit.edu/vera" class="link-sub">Vera: E-journals &amp; databases</a>
-				<a href="https://libraries.mit.edu/worldcat" class="link-sub">WorldCat</a>
-				<a href="https://libraries.mit.edu/barton-reserves" class="link-sub">Course reserves</a>
-				<a href="https://libraries.mit.edu/site-search" class="link-sub">Site search</a>
-				<a href="https://libraries.mit.edu/search" class="link-sub">More search options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/hours">Hours &amp; locations</a></h4>
-				<a href="https://libraries.mit.edu/hours" class="link-sub">Hours</a>
-				<a href="https://libraries.mit.edu/locations" class="link-sub">Map of locations</a>
-				<a href="https://libraries.mit.edu/study" class="link-sub">Study spaces</a>
-				<a href="https://libraries.mit.edu/exhibits" class="link-sub">Exhibits &amp; galleries</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/borrow">Borrow &amp; request</a></h4>
-				<a href="https://libraries.mit.edu/barton-account" class="link-sub">Your Account</a>
-				<a href="https://libraries.mit.edu/getit" class="link-sub">Get it: options for getting books &amp; articles</a>
-				<a href="https://libraries.mit.edu/circ" class="link-sub">Circulation FAQ</a>
-				<a href="https://libraries.mit.edu/reserves" class="link-sub">Reserves &amp; TIP FAQ</a>
-				<a href="https://libraries.mit.edu/otherlibraries" class="link-sub">Visit non-MIT libraries</a>
-				<a href="https://libraries.mit.edu/borrow" class="link-sub">More borrow &amp; request options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/research-support">Research support</a></h4>
-				<a href="https://libraries.mit.edu/ask" class="link-sub">Ask us</a>
-				<a href="https://libraries.mit.edu/experts" class="link-sub">Research guides &amp; expert librarians</a>
-				<a href="https://libraries.mit.edu/productivity-tools" class="link-sub">Productivity tools</a>
-				<a href="https://libraries.mit.edu/scholarly" class="link-sub">Scholarly publishing</a>
-				<a href="https://libraries.mit.edu/references" class="link-sub">Citation &amp; writing tools</a>
-				<a href="https://libraries.mit.edu/research-support" class="link-sub">More research support options</a>
-			</div>
-			<div class="flex-item">
-				<h4><a href="https://libraries.mit.edu/about">About us</a></h4>
-				<a href="https://libraries.mit.edu/contact" class="link-sub">Contact us</a>
-				<a href="https://libraries.mit.edu/news" class="link-sub">News</a>
-				<a href="https://libraries.mit.edu/events" class="link-sub">Classes &amp; events</a>
-				<a href="https://libraries.mit.edu/use-policies" class="link-sub">Use policy</a>
-				<a href="https://libraries.mit.edu/site-search/" class="link-sub">Services A-Z</a>
-				<a href="https://libraries.mit.edu/about" class="link-sub">More about us</a>
-			</div>
-		</div><!-- end div.links-all -->
-		
-		<div class="identity flex-container">
-			<a href="https://libraries.mit.edu/" class="logo-mit-lib" alt="MIT Libraries Logo">
-				<svg xmlns="http://www.w3.org/2000/svg" width="193.9" height="77.55" viewBox="0 0 193.9 77.55"><title>MIT Libraries logo</title><path d="M5.3,5.55H17.2L21.55,21.2q0.25,0.85.58,2.22T22.8,26.1q0.4,1.55.8,3.25h0.1q0.35-1.7.75-3.25,0.3-1.3.65-2.67t0.6-2.22L30.1,5.55h12V41.3H34V21.58q0-1.17,0-2.37,0-1.4.1-3.05H34q-0.4,1.55-.7,2.85t-0.53,2.22q-0.28,1.08-.42,1.58L27.25,41.3h-7.3l-5.1-18.45q-0.15-.5-0.45-1.6T13.85,19q-0.3-1.3-.65-2.85H13.1q0,1.65,0,3.05,0,1.2.08,2.4t0,1.75v18h-8V5.55Zm40,0h8.85V41.3H45.32V5.55ZM67.4,13H57V5.55H86.75V13H76.25V41.3H67.4V13ZM5.3,46.55h8.85V74.8H30.82v7.5H5.3V46.55Zm28.7,0h8.15v6.6H34v-6.6ZM34,56.7h8.15V82.3H34V56.7ZM61,83.1a9.84,9.84,0,0,1-4.55-1,7.87,7.87,0,0,1-3.2-3h-0.1V82.3h-7.8V46.55h8.15v13h0.15A9.45,9.45,0,0,1,56.55,57a8.63,8.63,0,0,1,4.37-1,9.89,9.89,0,0,1,4.53,1,10.16,10.16,0,0,1,3.45,2.85,13.44,13.44,0,0,1,2.2,4.3,17.91,17.91,0,0,1,.78,5.38,19.49,19.49,0,0,1-.78,5.72,12.5,12.5,0,0,1-2.2,4.28,9.47,9.47,0,0,1-3.45,2.67A10.66,10.66,0,0,1,61,83.1Zm-2.3-6.45a4.14,4.14,0,0,0,3.67-1.92,9.45,9.45,0,0,0,1.28-5.27,9.74,9.74,0,0,0-1.28-5.3,4.19,4.19,0,0,0-3.77-2,4.44,4.44,0,0,0-4,2.1,9.66,9.66,0,0,0-1.33,5.25,8.53,8.53,0,0,0,1.45,5.17A4.69,4.69,0,0,0,58.67,76.65ZM73.81,56.7h7.8v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27Q82,66.6,82,70.8V82.3H73.81V56.7ZM99.76,83a12,12,0,0,1-3.53-.5A7.54,7.54,0,0,1,93.46,81a7,7,0,0,1-1.8-2.45A8.11,8.11,0,0,1,91,75.15a7.29,7.29,0,0,1,.78-3.52,6.67,6.67,0,0,1,2.12-2.35A10.55,10.55,0,0,1,97,67.85a25.72,25.72,0,0,1,3.77-.75,24.65,24.65,0,0,0,5-1,1.92,1.92,0,0,0,1.45-1.85,2.57,2.57,0,0,0-.83-2,3.92,3.92,0,0,0-2.67-.75,4.45,4.45,0,0,0-3,.85,3.67,3.67,0,0,0-1.2,2.45h-7.5a8.46,8.46,0,0,1,.8-3.4,8.17,8.17,0,0,1,2.17-2.8,10.56,10.56,0,0,1,3.58-1.9,16.34,16.34,0,0,1,5-.7,19.62,19.62,0,0,1,4.9.52,9.73,9.73,0,0,1,3.4,1.58,7.29,7.29,0,0,1,2.45,3,10.63,10.63,0,0,1,.8,4.25V78.3a13,13,0,0,0,.17,2.42,1.78,1.78,0,0,0,.73,1.23V82.3h-7.9a3.37,3.37,0,0,1-.5-1.12,14.64,14.64,0,0,1-.35-1.72h-0.1A8.47,8.47,0,0,1,104.44,82,9.92,9.92,0,0,1,99.76,83Zm2.6-5.2a5.45,5.45,0,0,0,3.73-1.25,4.23,4.23,0,0,0,1.42-3.35v-3a11.85,11.85,0,0,1-1.87.73q-1.08.33-2.33,0.63a10.45,10.45,0,0,0-3.4,1.27,2.47,2.47,0,0,0-1.05,2.17,2.42,2.42,0,0,0,1,2.2A4.5,4.5,0,0,0,102.36,77.75Zm15.87-21H126v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.23,1.83-2.23,6V82.3h-8.15V56.7Zm18.94-10.15h8.15v6.6h-8.15v-6.6Zm0,10.15h8.15V82.3h-8.15V56.7Zm24,26.35a15.16,15.16,0,0,1-5.7-1,12.12,12.12,0,0,1-4.3-2.85,12.66,12.66,0,0,1-2.7-4.33,15.06,15.06,0,0,1-1-5.4,14.72,14.72,0,0,1,1-5.33,12.71,12.71,0,0,1,2.7-4.3A12.46,12.46,0,0,1,155.3,57a14.58,14.58,0,0,1,10.28-.17,12.28,12.28,0,0,1,3.83,2.35,12.76,12.76,0,0,1,3.42,5.33,20.72,20.72,0,0,1,1.08,7.13H155.5a7.52,7.52,0,0,0,1.8,4.1,5.14,5.14,0,0,0,4,1.5,4.81,4.81,0,0,0,2.65-.68,4.3,4.3,0,0,0,1.6-1.87h8a9.47,9.47,0,0,1-1.5,3.33,10.65,10.65,0,0,1-2.8,2.73,12.12,12.12,0,0,1-3.58,1.75A15.22,15.22,0,0,1,161.15,83Zm4.5-16.3a6,6,0,0,0-1.55-3.65,4.39,4.39,0,0,0-3.3-1.35,4.66,4.66,0,0,0-3.6,1.35,7,7,0,0,0-1.65,3.65h10.1Zm21.9,16.35q-5.65,0-8.95-2.42A8.35,8.35,0,0,1,175.1,74h7.7a4.15,4.15,0,0,0,1.45,2.85,5.09,5.09,0,0,0,3.25,1,5.63,5.63,0,0,0,2.92-.65,2.09,2.09,0,0,0,1.08-1.9,1.82,1.82,0,0,0-.55-1.37,4.08,4.08,0,0,0-1.45-.85,10.92,10.92,0,0,0-2.08-.5q-1.17-.17-2.42-0.42-1.65-.3-3.3-0.72a10.14,10.14,0,0,1-3-1.28,6.33,6.33,0,0,1-2.12-2.27,7.45,7.45,0,0,1-.8-3.68,7.1,7.1,0,0,1,.87-3.55A7.64,7.64,0,0,1,179,58a11.18,11.18,0,0,1,3.53-1.55,17,17,0,0,1,4.28-.52q5.45,0,8.35,2.2a8,8,0,0,1,3.2,6h-7.5a3,3,0,0,0-1.33-2.37,5.48,5.48,0,0,0-2.78-.62,5.1,5.1,0,0,0-2.52.58,1.9,1.9,0,0,0-1,1.78,1.33,1.33,0,0,0,.5,1.1,4.21,4.21,0,0,0,1.35.67,14.86,14.86,0,0,0,2,.48l2.33,0.4q1.7,0.3,3.42.73A10.59,10.59,0,0,1,196,68.2a7.05,7.05,0,0,1,2.32,2.42,7.75,7.75,0,0,1,.9,4A7.35,7.35,0,0,1,195.9,81a11.75,11.75,0,0,1-3.7,1.6A18.75,18.75,0,0,1,187.54,83.1Z" transform="translate(-5.3 -5.55)" /></svg>
-				<span class="sr">MIT Libraries</span>
-			</a><!-- End MIT Libraries Logo -->
-			
-			<div class="social flex-container">
-				<p class="text-find-us">Find us on</p>
-					<a href="https://twitter.com/mitlibraries" title="Twitter">
-						<svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black" /></g></svg>
-						<span class="sr">Twitter</span>
-					</a><!-- End Twitter -->
-					
-					<a href="https://libraries.mit.edu/facebook" title="Facebook">
-						<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
-						<span class="sr">Facebook</span>
-					</a><!-- End Facebook -->
-					
-					<a href="https://instagram.com/mitlibraries/" title="Instagram">
-						<svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2
-	c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1
-	c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4
-	C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0
-	c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4
-	c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z
-	 M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z
-	 M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
-	c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
-						<span class="sr">Instagram</span>
+<footer>
+<div class="wrap-outer-footer layout-band">
+    <div class="wrap-footer footer-slim">
+        <div class="footer-main" aria-label="MIT Libraries footer">
+            <div class="identity">
+                <div class="wrap-logo-lib">
+                    <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
+											<svg xmlns="http://www.w3.org/2000/svg" width="194.05" height="77.65" viewBox="0 0 194.05 77.65"><title>MIT Libraries Logo</title><path d="M0,0H11.9l4.35,15.65q0.25,0.85.58,2.22t0.67,2.68q0.4,1.55.8,3.25h0.1q0.35-1.7.75-3.25,0.3-1.3.65-2.67t0.6-2.22L24.8,0h12V35.75H28.7V13.66q0-1.4.1-3.05H28.7q-0.4,1.55-.7,2.85t-0.53,2.22q-0.28,1.08-.42,1.58l-5.1,18.49h-7.3L9.55,17.3Q9.4,16.8,9.1,15.7T8.55,13.45q-0.3-1.3-.65-2.85H7.8v3.05q0,1.2.08,2.4a9.26,9.26,0,0,1,0,1.75v18h-8V0H0ZM40,0h8.85V35.75H40V0h0ZM62.1,7.45H51.7V0H81.45V7.45H70.95v28.3H62.1V7.45ZM0,41H8.85V69.25H25.52v7.5H0V41Zm28.7,0h8.15v6.6H28.7V41Zm0,10.15h8.15v25.6H28.7V51.15Zm27,26.4a9.84,9.84,0,0,1-4.55-1,7.87,7.87,0,0,1-3.2-3h-0.1v3.2h-7.8V41H48.2V54h0.15a9.45,9.45,0,0,1,2.9-2.55,8.63,8.63,0,0,1,4.37-1,9.89,9.89,0,0,1,4.53,1A10.16,10.16,0,0,1,63.6,54.3a13.44,13.44,0,0,1,2.2,4.3A17.91,17.91,0,0,1,66.58,64a19.49,19.49,0,0,1-.78,5.72A12.5,12.5,0,0,1,63.6,74a9.47,9.47,0,0,1-3.45,2.67A10.66,10.66,0,0,1,55.7,77.55ZM53.4,71.1a4.14,4.14,0,0,0,3.67-1.92,9.45,9.45,0,0,0,1.28-5.27,9.74,9.74,0,0,0-1.28-5.3,4.19,4.19,0,0,0-3.77-2,4.44,4.44,0,0,0-4,2.1A9.66,9.66,0,0,0,48,64a8.53,8.53,0,0,0,1.45,5.17,4.69,4.69,0,0,0,4,2h0Zm15.11-20h7.8v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.16,1.78-2.16,6v11.5H68.51V51.15Zm26,26.3a12,12,0,0,1-3.53-.5,7.54,7.54,0,0,1-2.77-1.5A7,7,0,0,1,86.36,73a8.11,8.11,0,0,1-.66-3.4,7.29,7.29,0,0,1,.78-3.52,6.67,6.67,0,0,1,2.12-2.35,10.55,10.55,0,0,1,3.1-1.43,25.72,25.72,0,0,1,3.77-.75,24.65,24.65,0,0,0,5-1,1.92,1.92,0,0,0,1.45-1.85,2.57,2.57,0,0,0-.83-2A3.92,3.92,0,0,0,98.42,56a4.45,4.45,0,0,0-3,.85,3.67,3.67,0,0,0-1.2,2.45h-7.5a8.46,8.46,0,0,1,.8-3.4,8.17,8.17,0,0,1,2.17-2.8,10.56,10.56,0,0,1,3.58-1.9,16.34,16.34,0,0,1,5-.7,19.62,19.62,0,0,1,4.9.52,9.73,9.73,0,0,1,3.4,1.58,7.29,7.29,0,0,1,2.45,3,10.63,10.63,0,0,1,.8,4.25V72.75a13,13,0,0,0,.17,2.42,1.78,1.78,0,0,0,.73,1.23v0.35h-7.9a3.37,3.37,0,0,1-.5-1.12,14.64,14.64,0,0,1-.35-1.72h-0.1a8.47,8.47,0,0,1-2.73,2.54A9.92,9.92,0,0,1,94.46,77.45Zm2.6-5.2A5.45,5.45,0,0,0,100.79,71a4.23,4.23,0,0,0,1.42-3.35v-3a11.85,11.85,0,0,1-1.87.73Q99.26,65.71,98,66a10.45,10.45,0,0,0-3.4,1.27,2.47,2.47,0,0,0-1.05,2.17,2.42,2.42,0,0,0,1,2.2,4.5,4.5,0,0,0,2.5.55v0.05Zm15.87-21h7.77v4h0.15a9.63,9.63,0,0,1,3-3.35,7.29,7.29,0,0,1,4-1,4.41,4.41,0,0,1,1.6.2v7h-0.2a7.36,7.36,0,0,0-6,1.27q-2.23,1.83-2.23,6V76.75h-8.15V51.15ZM131.87,41.1H140v6.6h-8.15V41.1Zm0,10.15H140v25.5h-8.15V51.25Zm24,26.35a15.16,15.16,0,0,1-5.7-1,12.12,12.12,0,0,1-4.3-2.85,12.66,12.66,0,0,1-2.7-4.33,15.06,15.06,0,0,1-1-5.4,14.72,14.72,0,0,1,1-5.33,12.71,12.71,0,0,1,2.7-4.3A12.46,12.46,0,0,1,150,51.45a14.58,14.58,0,0,1,10.28-.17,12.28,12.28,0,0,1,3.83,2.35A12.76,12.76,0,0,1,167.53,59a20.72,20.72,0,0,1,1.08,7.13H150.2a7.52,7.52,0,0,0,1.8,4.1,5.14,5.14,0,0,0,4,1.5,4.81,4.81,0,0,0,2.65-.68,4.3,4.3,0,0,0,1.6-1.87h8a9.47,9.47,0,0,1-1.5,3.33,10.65,10.65,0,0,1-2.8,2.73A12.12,12.12,0,0,1,160.37,77a15.22,15.22,0,0,1-4.52.5Zm4.5-16.3a6,6,0,0,0-1.55-3.65,4.39,4.39,0,0,0-3.3-1.35,4.66,4.66,0,0,0-3.6,1.35,7,7,0,0,0-1.65,3.65h10.1Zm21.9,16.35q-5.65,0-8.95-2.42a8.35,8.35,0,0,1-3.52-6.78h7.7a4.15,4.15,0,0,0,1.45,2.85,5.09,5.09,0,0,0,3.25,1,5.63,5.63,0,0,0,2.92-.65,2.09,2.09,0,0,0,1.08-1.9,1.82,1.82,0,0,0-.55-1.37,4.08,4.08,0,0,0-1.45-.85,10.92,10.92,0,0,0-2.08-.5q-1.17-.17-2.42-0.42-1.65-.3-3.3-0.72a10.14,10.14,0,0,1-3-1.28,6.33,6.33,0,0,1-2.12-2.27,7.45,7.45,0,0,1-.8-3.68,7.1,7.1,0,0,1,.87-3.55,7.64,7.64,0,0,1,2.35-2.66,11.18,11.18,0,0,1,3.53-1.55,17,17,0,0,1,4.28-.52q5.45,0,8.35,2.2a8,8,0,0,1,3.2,6h-7.5a3,3,0,0,0-1.33-2.37,5.48,5.48,0,0,0-2.78-.62,5.1,5.1,0,0,0-2.52.58,1.9,1.9,0,0,0-1,1.78,1.33,1.33,0,0,0,.5,1.1,4.21,4.21,0,0,0,1.35.67,14.86,14.86,0,0,0,2,.48l2.33,0.4q1.7,0.3,3.42.73a10.59,10.59,0,0,1,3.17,1.32A7.05,7.05,0,0,1,193,65.07a7.75,7.75,0,0,1,.9,4,7.35,7.35,0,0,1-3.32,6.38,11.75,11.75,0,0,1-3.7,1.6,18.75,18.75,0,0,1-4.66.5Z" transform="translate(0.12)" fill="#fff"/></svg>
+                    </a>
+                </div>
+                <div class="wrap-social">
+                    <p class="text-find-us">Find us on</p>
+                    <a href="//twitter.com/mitlibraries" title="Twitter">
+                        <svg class="icon-social--twitter" width="2048" height="2048" viewBox="-192 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M1620 1128q-67 -98 -162 -167q1 -14 1 -42q0 -130 -38 -259.5t-115.5 -248.5t-184.5 -210.5t-258 -146t-323 -54.5q-271 0 -496 145q35 -4 78 -4q225 0 401 138q-105 2 -188 64.5t-114 159.5q33 -5 61 -5q43 0 85 11q-112 23 -185.5 111.5t-73.5 205.5v4q68 -38 146 -41 q-66 44 -105 115t-39 154q0 88 44 163q121 -149 294.5 -238.5t371.5 -99.5q-8 38 -8 74q0 134 94.5 228.5t228.5 94.5q140 0 236 -102q109 21 205 78q-37 -115 -142 -178q93 10 186 50z" fill="black"></path></g></svg>
+                        <span class="sr">Twitter</span>
+                    </a><!-- End Twitter -->
+                    
+                    <a href="https://www.facebook.com/mitlib" title="Facebook">
+                        <svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black"></path></g></svg>
+                        <span class="sr">Facebook</span>
+                    </a><!-- End Facebook -->
+                    
+                    <a href="//instagram.com/mitlibraries/" title="Instagram">
+                        <svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1 c4,0.5,7.2,3.6,8,7.5c0.1,0.4,0.1,0.8,0.2,1.2v70.2c-0.1,0.4-0.1,0.8-0.2,1.2c-0.7,3.6-3.6,6.6-7.2,7.4 C96,103.7,95.5,103.8,95.1,103.9z M25.6,51.7v0.2c0,13,0,26,0,38.9c0,1.9,1.6,3.5,3.5,3.5c20.6,0,41.2,0,61.8,0 c1.9,0,3.5-1.6,3.5-3.5c0-13,0-25.9,0-38.9v-0.3H86c1.2,3.8,1.5,7.6,1.1,11.5c-0.5,3.9-1.7,7.6-3.8,10.9c-2.1,3.4-4.7,6.2-8,8.4 c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C31.2,51.7,28.4,51.7,25.6,51.7L25.6,51.7z M60,42.2c-9.7,0-17.6,7.8-17.8,17.5c-0.1,9.9,7.8,17.8,17.4,18c9.9,0.2,18-7.7,18.2-17.4C78,50.4,70,42.2,60,42.2L60,42.2z M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"></path></svg>
+                        <span class="sr">Instagram</span>
+                    </a><!-- End Instagram -->
+                    
+                    <a href="//www.youtube.com/user/MITLibraries" title="YouTube">
+                        <svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
+                        <span class="sr">YouTube</span>
+                    </a><!-- End YouTube -->
 
-					</a><!-- End Instagram -->
-					
-					<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
-						<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
-						<span class="sr">YouTube</span>
-					</a><!-- End YouTube -->
-
-					<a href="//libguides.mit.edu/mit-feeds" title="RSS">
-						<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
-						<span class="sr">RSS</span>
-					</a><!-- End RSS -->
-
-			</div><!-- end div.social -->
-			
-			<div class="links-primary flex-container">
-				<span><a href="https://libraries.mit.edu/faculty" class="link-sub">Faculty</a></span>
-				<span><a href="https://libraries.mit.edu/alumni" class="link-sub">Alumni</a></span>
-				<span><a href="https://libraries.mit.edu/visitors" class="link-sub">Visitors</a></span>
-				<span><a href="https://libraries.mit.edu/giving" class="link-sub">Giving</a></span>
-				<span><a href="https://libraries.mit.edu/disabilities" class="link-sub">Persons with disabilities</a></span>
-			</div><!-- End div.links-primary -->
-			
-		</div><!-- End div.identity -->
-	</div>
-	
-	<div class="footer-info-institute">
-		<a class="link-logo-mit" href="http://www.mit.edu">
-			<span class="sr">MIT</span>
-			<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
-		</a><!-- End MIT Logo -->
-		
-		<div class="about-mit">
-			<span>MASSACHUSETTS INSTITUTE OF TECHNOLOGY </span>
-			<span>77 MASSACHUSETTS AVENUE </span>
-			<span>CAMBRIDGE MA 02139-4307</span>
-		</div><!-- End div.about-mit -->
-		
-		<div class="license">Licensed under the <a href="http://creativecommons.org/licenses/by-nc/2.0/" class="license-cc">Creative Commons Attribution Non-Commercial License</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
-		</div><!-- End footer.footer-info-institure -->
-	</div>
+                    <a href="//libguides.mit.edu/mit-feeds" title="RSS">
+                        <svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black"></path></g></svg>
+                        <span class="sr">RSS</span>
+                    </a><!-- End RSS -->
+                </div><!-- end .social -->
+                <div class="wrap-middle">
+                    <div class="wrap-sitemap">
+                        <nav class="sitemap-libraries-abbrev" aria-label="MIT Libraries site menu">
+                            <h2 class="sr">MIT Libraries navigation</h2>
+                            <a class="item" href="https://libraries.mit.edu/search">Search</a>
+                            <a class="item" href="https://libraries.mit.edu/hours">Hours &amp; locations</a>
+                            <a class="item" href="https://libraries.mit.edu/borrow">Borrow &amp; request</a>
+                            <a class="item" href="https://libraries.mit.edu/research-support">Research support</a>
+                            <a class="item" href="https://libraries.mit.edu/about">About us</a>
+                        </nav>
+                    </div><!-- end .links-all -->
+                    <div class="wrap-policies">
+                        <nav aria-label="MIT Libraries policy menu">
+                            <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+                            <span class="item"><a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a></span>
+                            <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
+                        </nav>
+                    </div>
+                </div>
+            </div><!-- end .identity -->
+        </div>
+    </div>
+</div>
+<div class="wrap-outer-footer-institute layout-band">
+    <div class="wrap-footer-institute">
+        <div class="footer-info-institute">
+            <a class="link-logo-mit" href="https://www.mit.edu">
+                <span class="sr">MIT</span>
+                <svg version="1.1" xmlns="https://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"/><rect width="5.8" height="28"/><rect x="9.6" width="5.8" height="18.8"/><rect x="19.3" width="5.8" height="28"/><rect x="38.5" y="8.9" width="5.8" height="19.1"/><rect x="38.8" width="15.2" height="5.6"/><rect x="28.9" width="5.8" height="5.6"/></svg>
+            </a>
+            <div class="about-mit">
+                <span class="item">Massachusetts Institute of Technology</span>
+            </div>
+            <div class="license">Content created by the MIT Libraries, <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a> unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
+            </div><!-- end .footer-info-institute -->
+        </div>
+    </div>
+</div>
 </footer>
 <script src="//v2.libanswers.com/load_chat.php?hash=be2c654b63dd43f31c56295ee5d78d88"></script>

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -804,407 +804,393 @@ svg {
 }
 
 /* 2. Footer */
-.footer-main {
-  background: #000 url('https://libraries.mit.edu/images/vi-shape7-tp.png') no-repeat 0 65%;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+.wrap-footer {
+  font-size: 12px;
+}
+.wrap-footer .wrap-policies, .wrap-footer.footer-slim .sitemap-libraries-abbrev a {
+  padding-left: 0;
+}
+.wrap-footer .wrap-policies li, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li,
+.wrap-footer .wrap-policies .item,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item {
+  display: inline-block;
+  padding-right: 1rem;
+}
+.wrap-footer .wrap-policies li:after, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li:after,
+.wrap-footer .wrap-policies .item:after,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item:after {
+  content: ' | ';
+  margin-left: 1rem;
+}
+.wrap-footer .wrap-policies li:last-child:after, .wrap-footer.footer-slim .sitemap-libraries-abbrev a li:last-child:after,
+.wrap-footer .wrap-policies .item:last-child:after,
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a .item:last-child:after {
+  content: '';
+}
+.layout-band:after {
+  content: '';
+  display: table;
   clear: both;
-  width: 100%
+}
+.wrap-footer,
+.wrap-footer-institute {
+  max-width: 114rem;
+  margin: 0 auto;
+  padding: 10px 4%;
+}
+.wrap-footer:after,
+.wrap-footer-institute:after {
+  content: '';
+  display: table;
+  clear: both;
+}
+.wrap-outer-footer {
+  background-color: #000;
+  color: #fff;
+  font-size: 1.2em;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-main {
-    padding: 2em 1.375em
-  }
+.wrap-footer {
+  padding: 3.5rem 4%;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main {
-    width: 100%
-  }
+.wrap-footer .wrap-sitemap .menu-sub {
+  display: none;
 }
-
-.footer-main a {
-  color: #fff
+.wrap-footer .identity {
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
-
-.footer-main .identity {
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 2em 0 0
+.wrap-footer .wrap-logo-lib {
+  display: inline-block;
+  vertical-align: bottom;
+  margin: 0 20px 20px 0;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main .identity {
-    -webkit-box-align: end;
-    -webkit-align-items: flex-end;
-    -ms-flex-align: end;
-    align-items: flex-end;
-    -webkit-box-pack: justify;
-    -webkit-justify-content: space-between;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
-    width: 100%
-  }
+.wrap-footer .wrap-social {
+  display: inline-block;
+  vertical-align: bottom;
+  margin-bottom: 20px;
 }
-
-.footer-main .links-all {
-  display: none
+.wrap-footer .wrap-policies {
+  width: 100%;
+  border-top: 1px solid #595959;
+  padding-top: 2rem;
 }
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all {
+.wrap-footer .wrap-policies span {
+  display: inline-block;
+  margin: 1rem 1.5rem 1rem 0;
+}
+.wrap-footer .wrap-policies span.item {
+  margin-right: 0;
+}
+.wrap-footer .wrap-policies span:after {
+  content: '';
+}
+.wrap-footer .wrap-social .text-find-us {
+  display: none;
+}
+@media (min-width: 768px) {
+  .wrap-footer .wrap-sitemap {
     display: -webkit-box;
-    display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    width: 100%
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
   }
-}
-
-.footer-main .links-all h4 {
-  font-size: 1.125em;
-  font-weight: 400;
-  padding-bottom: 1em
-}
-
-.footer-main .links-all .flex-item {
-  margin-right: 1.75em
-}
-
-.footer-main .links-all .link-sub {
-  display: block;
-  font-size: .75em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-all .link-sub {
-    font-size: .75em;
-    font-weight: 300
+  .wrap-footer .wrap-sitemap .col {
+    margin-right: 3%;
   }
-  .footer-main .links-all .link-sub:not(:last-of-type) {
-    padding-bottom: 1em
+  .wrap-footer .wrap-sitemap .col:last-child {
+    margin-right: 0;
   }
-}
-
-.footer-main .links-primary {
-  border-top: 1px solid #808285;
-  border-bottom: 1px solid #808285;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  font-size: .8125em;
-  margin-top: 2em;
-  padding: 2rem 1.375rem;
-  width: 100%
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary {
+  .wrap-footer .wrap-sitemap .menu-sub {
+    display: block;
+  }
+  .wrap-footer .identity {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+    -webkit-box-pack: justify;
+        -ms-flex-pack: justify;
+            justify-content: space-between;
+    margin: 4% 0 0 0;
+  }
+  .wrap-footer .wrap-logo-lib,
+  .wrap-footer .wrap-policies,
+  .wrap-footer .wrap-social {
+    -ms-flex-item-align: end;
+        align-self: flex-end;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .wrap-footer .wrap-logo-lib {
+    -webkit-box-ordinal-group: 2;
+        -ms-flex-order: 1;
+            order: 1;
+    margin-right: 4%;
+  }
+  .wrap-footer .wrap-policies {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+    padding: auto;
     border-top: none;
-    border-bottom: none;
-    font-size: .875em;
-    margin-top: -22.4px;
-    margin-top: -1.4rem;
-    margin-left: 184px;
-    margin-left: 11.5rem;
-    padding: 0;
-    z-index: 3000
+    width: auto;
+  }
+  .wrap-footer .wrap-policies span {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .wrap-footer .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+    margin-left: auto;
+  }
+}
+@media (min-width: 1024px) {
+  .wrap-footer .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
+  }
+  .wrap-footer .wrap-policies {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
   }
 }
 
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary {
-    margin-top: 24px;
-    margin-top: 1.5rem;
-    margin-left: 0;
-    margin-left: 0
-  }
+.wrap-footer.footer-slim {
+  padding: 1.5rem 4%;
 }
-
-.footer-main .links-primary span {
+.wrap-footer.footer-slim .wrap-middle {
+  -webkit-box-ordinal-group: 3;
+      -ms-flex-order: 2;
+          order: 2;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-align: start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+}
+.wrap-footer.footer-slim .wrap-middle .wrap-policies {
+  -ms-flex-item-align: start;
+      align-self: flex-start;
+}
+.wrap-footer.footer-slim .wrap-middle .wrap-sitemap {
+  display: inline-block;
+  margin-bottom: 2rem;
+}
+.wrap-footer.footer-slim .wrap-middle .wrap-sitemap .item {
   display: block;
-  width: 50%
+  margin-right: 10px;
+  margin-bottom: 5px;
 }
-
-.footer-main .links-primary span:not(:last-of-type) {
-  margin-bottom: 1.5em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .links-primary span {
-    font-weight: 300;
-    padding-left: 1em;
-    width: auto
+@media (min-width: 768px) {
+  .wrap-footer.footer-slim .wrap-middle {
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
   }
-  .footer-main .links-primary span:not(:last-of-type):after {
-    color: #dedede;
-    content: '|';
+  .wrap-footer.footer-slim .wrap-middle .wrap-policies {
+    margin-left: 2%;
+    -webkit-box-ordinal-group: 3;
+        -ms-flex-order: 2;
+            order: 2;
+  }
+  .wrap-footer.footer-slim .wrap-middle .wrap-sitemap {
     display: inline-block;
-    margin-left: 1em
+    margin-left: 2%;
+    margin-bottom: auto;
+    -webkit-box-ordinal-group: 2;
+        -ms-flex-order: 1;
+            order: 1;
+  }
+  .wrap-footer.footer-slim .wrap-middle .wrap-sitemap .item {
+    display: inline-block;
+    margin-bottom: auto;
+  }
+  .wrap-footer.footer-slim .wrap-social {
+    -webkit-box-ordinal-group: 4;
+        -ms-flex-order: 3;
+            order: 3;
   }
 }
 
-@media only screen and (max-width:1023px) {
-  .footer-main .links-primary span:first-of-type {
-    padding-left: 0
-  }
+.wrap-footer-institute {
+  padding: 20px 4%;
 }
 
-.footer-main .logo-mit-lib {
-  display: block;
-  fill: #fff;
-  padding-left: 1.375em;
-  width: 10.3125em
+.wrap-content li {
+  margin-bottom: .5em;
+}
+.wrap-content .title-page {
+  margin-bottom: 1rem;
+  padding: .5rem 0 1rem 0;
+  font-weight: 600;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-main .logo-mit-lib {
-    padding-left: 0;
-    max-width: 9.5em;
-    width: 9.5em
-  }
+.wrap-footer {
+  background: #000 url("https://libraries.mit.edu/images/vi-shape7-tp.png") no-repeat 10%;
 }
-
-.footer-main .logo-mit-lib svg {
-  max-height: 4em;
-  max-width: 9.5em
-}
-
-.footer-main .text-find-us {
+.wrap-footer a {
   color: #fff;
-  display: none;
-  font-size: .625em;
-  font-weight: 700;
+  text-decoration: none;
+}
+.wrap-footer a:hover, .wrap-footer a:active, .wrap-footer a:focus {
+  text-decoration: underline;
+  color: #fff;
+}
+.wrap-footer .title {
+  margin-bottom: .8rem;
+}
+.wrap-footer .wrap-list .link-sub {
+  display: list-item;
+  list-style-type: none;
+  margin-bottom: .65rem;
+  font-weight: 300;
+}
+.wrap-footer .logo-mit-lib {
+  fill: #fff;
+}
+.wrap-footer .logo-mit-lib svg {
+  max-height: 60px;
+  max-width: 100%;
+  vertical-align: baseline;
+}
+.wrap-footer .wrap-policies {
+  font-size: 1.4em;
+}
+.wrap-footer .wrap-social p, .wrap-footer .wrap-social a {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: .5rem;
+  margin-bottom: 0;
   text-transform: uppercase;
-  min-width: 7em
+  font-size: 1.2em;
+}
+.wrap-footer .wrap-social svg {
+  height: 2em;
+  width: 2em;
+  border-radius: 50%;
+  padding: 0.2em;
+  background: #fff none repeat scroll 0 0;
+}
+.wrap-footer .wrap-social svg path {
+  fill: #333;
 }
 
-@media only screen and (min-width:569px) {
-  .footer-main .text-find-us {
-    display: block
-  }
+.wrap-footer.footer-slim .sitemap-libraries-abbrev a {
+  font-size: 1.4em;
 }
 
-.footer-main .social {
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding-left: 1.375em;
+.wrap-outer-footer-institute {
+  background-color: #333;
+  font-size: 12px;
+  color: #dedede;
+}
+.wrap-outer-footer-institute .footer-info-institute {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
+}
+.wrap-outer-footer-institute a {
+  color: #fff;
+}
+.wrap-outer-footer-institute a:hover, .wrap-outer-footer-institute a:active, .wrap-outer-footer-institute a:focus {
+  color: #fff;
+}
+.wrap-outer-footer-institute .link-logo-mit .logo-mit {
+  fill: #ccc;
+}
+.wrap-outer-footer-institute .link-logo-mit .logo-mit .color {
+  fill: #fff;
+}
+.wrap-outer-footer-institute .about-mit {
+  color: #dedede;
+  margin-right: 4%;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.wrap-outer-footer-institute .license {
+  margin-left: auto;
+  margin-top: 1rem;
+  color: #dedede;
+}
+
+/* 3. no-flexbox fallbacks */
+.no-flexbox.no-flexboxlegacy .flex-clear {
+  clear: both
+}
+
+.no-flexbox.no-flexboxlegacy .flex-container {
+  display: block
+}
+
+.no-flexbox.no-flexboxlegacy .flex-container>a,
+.no-flexbox.no-flexboxlegacy .flex-container>button,
+.no-flexbox.no-flexboxlegacy .flex-container>div,
+.no-flexbox.no-flexboxlegacy .flex-container>form,
+.no-flexbox.no-flexboxlegacy .flex-container>h1,
+.no-flexbox.no-flexboxlegacy .flex-container>h2,
+.no-flexbox.no-flexboxlegacy .flex-container>h3,
+.no-flexbox.no-flexboxlegacy .flex-container>header,
+.no-flexbox.no-flexboxlegacy .flex-container>input,
+.no-flexbox.no-flexboxlegacy .flex-container>nav,
+.no-flexbox.no-flexboxlegacy .flex-container>span,
+.no-flexbox.no-flexboxlegacy .flex-container>svg,
+.no-flexbox.no-flexboxlegacy .flex-container>ul {
+  float: left;
   width: auto
 }
 
-@media only screen and (min-width:569px) {
-  .footer-main .social {
-    -webkit-flex-wrap: nowrap;
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap;
-    margin-bottom: -.8em;
-    z-index: 4000
-  }
-}
-
-.footer-main .social a {
-  width: 33%
-}
-
-.footer-main .social a:hover {
-  text-decoration: none
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social a {
-    width: 20%
-  }
-  .footer-main .social a:not(:last-of-type) {
-    margin-right: .5em
-  }
-}
-
-.footer-main .social [class*=icon-social] {
-  background: #fff;
-  -webkit-border-radius: 50%;
-  border-radius: 50%;
-  height: 1.5em;
-  padding: .2em;
-  width: 1.5em
-}
-
-.footer-main .social [class*=icon-social] path {
-  fill: #000
-}
-
-@media only screen and (min-width:569px) {
-  .footer-main .social [class*=icon-social] {
-    height: 2em;
-    padding: .2em;
-    width: 2em
-  }
-}
-
-.footer-info-institute {
-  -webkit-box-align: baseline;
-  -webkit-align-items: baseline;
-  -ms-flex-align: baseline;
-  align-items: baseline;
-  background: #333;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 1.5em 1em
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row
-  }
-}
-
-.footer-info-institute .about-mit {
-  font-size: .625em;
-  margin-bottom: 2em
-}
-
-.footer-info-institute .about-mit span {
-  color: #eee;
-  text-transform: uppercase
-}
-
-.footer-info-institute .about-mit span:first-of-type {
-  font-weight: 700
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute .about-mit span {
-    color: #ededed
-  }
-  .footer-info-institute .about-mit span:not(:last-of-type):after {
-    content: '|';
-    font-weight: 400
-  }
-}
-
-.footer-info-institute .license {
-  color: #ededed;
-  font-size: .6875em;
-  width: 100%
-}
-
-.footer-info-institute .license a {
-  color: #ededed
-}
-
-.footer-info-institute .link-mit-home {
-  display: block
-}
-
-@media only screen and (min-width:569px) {
-  .footer-info-institute .link-mit-home {
-    margin: 0 1em 1.5em 0
-  }
-}
-
-.footer-info-institute .logo-mit {
-  fill: #bbb9b8;
-  width: 3.375em
-}
-
-.footer-info-institute .logo-mit .color {
-  fill: #ededed
-}
-
-.no-flexbox .footer-info-institute {
-  display: block
-}
-
-.no-flexbox .footer-info-institute:after {
+.no-flexbox.no-flexboxlegacy .flex-container:after {
   clear: both;
   content: '';
   display: table
 }
 
-.no-flexbox .footer-info-institute>a,
-.no-flexbox .footer-info-institute>div {
+.no-flexbox.no-flexboxlegacy .flex-item {
   float: left
 }
 
-.no-flexbox .footer-info-institute .about-mit {
-  padding-top: 4em
+/* 4. hiding and showing elements based on mobile classes */
+.hidden-mobile {
+  display: none;
 }
 
-.no-flexbox .footer-info-institute .link-mit-home {
-  padding-top: 1.5em
-}
-
-.no-flexbox .footer-main.flex-container {
+.hidden-non-mobile {
   display: block;
-  float: left
 }
 
-.no-flexbox .footer-main:after {
-  clear: both;
-  content: '';
-  display: table
+@media only screen and (min-width: 569px) {
+  .hidden-non-mobile {
+    display: none;
+  }
 }
 
-.no-flexbox .footer-main .identity {
-  position: relative;
-  width: 100%
-}
-
-.no-flexbox .footer-main .identity .logo-mit-lib {
-  display: block;
-  float: left
-}
-
-.no-flexbox .footer-main .identity .social {
-  bottom: 0;
-  display: block;
-  right: 22px;
-  position: absolute
-}
-
-.no-flexbox .footer-main .links-primary {
-  display: block;
-  margin-top: 0;
-  margin-left: 0;
-  left: 202px;
-  position: absolute;
-  top: 79px;
-  width: 100%
-}
-
-.no-flexbox .footer-main .links-primary span {
-  display: block;
-  float: left;
-  position: relative
-}
-
-.no-flexbox.flexboxlegacy .footer-main {
-  overflow-x: hidden
-}
-
-.lte-ie9.no-flexbox .footer-main .identity {
-  width: 100%
+@media only screen and (min-width: 569px) {
+  .hidden-mobile {
+    display: block;
+  }
 }
 
 /* 3. no-flexbox fallbacks */
@@ -1280,7 +1266,7 @@ svg {
 }
 
 .header-main, 
-.footer-main-wrap {
+.layout-band {
   max-width: 1170px; /* matches .container */
   width: 100%;
   margin: 0 auto;

--- a/libguides/custom-header.html
+++ b/libguides/custom-header.html
@@ -110,7 +110,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
             <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>

--- a/libwizard/custom-header.html
+++ b/libwizard/custom-header.html
@@ -98,7 +98,6 @@
         <div class="col-2 flex-item">
           <h3 class="heading-col">More information</h3>
           <ul class="list-unbulleted">
-            <li><a href="https://libraries.mit.edu/getit">Get it <span class="about">Understand your options</span></a></li>
             <li><a href="https://libraries.mit.edu/circ">Circulation FAQ <span class="about">Info about fines, renewing, etc.</span></a></li>
             <li><a href="https://libraries.mit.edu/reserves">Course reserves &amp; TIP FAQ</a></li>
             <li><a href="https://libraries.mit.edu/otherlibraries">Visit non-MIT libraries <span class="about">Harvard, Borrow Direct, etc.</span></a></li>


### PR DESCRIPTION
This updates all Springshare products (except LibWizard) with the new slim footer and removes the GetIt look from the headers.

LibWizard does not allow for custom footers. I talked with Stephanie about this, and she said it's okay to postpone that one.

You can view the changes live in the test groups below:

- LibGuides: https://libguides.mit.edu/mjbernha?b=g&d=a&group_id=3756
- LibAnswers https://libanswers.mit.edu/test-group

Unfortunately, LibCal does not support groups, and it doesn't appear to be possible to change the header/footer for individual calendars.

Related tickets:
- https://mitlibraries.atlassian.net/browse/UXWS-1029
- https://mitlibraries.atlassian.net/browse/ENGX-23
- https://mitlibraries.atlassian.net/browse/ENGX-24
- https://mitlibraries.atlassian.net/browse/ENGX-25