### PR TITLE
Remove height and width specifications for svg tags

### DIFF
--- a/libanswers/custom-head.html
+++ b/libanswers/custom-head.html
@@ -95,11 +95,6 @@ a:hover i {
   color: #00f;
 }
 
-svg {
-  max-width: 100%;
-  max-height: 100%;
-}
-
 .flex-container {
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/libanswers/custom-head.html
+++ b/libanswers/custom-head.html
@@ -136,6 +136,11 @@ a:hover i {
   width: 100%
 }
 
+.header-main svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 @media only screen and (min-width:569px) {
   .header-main {
     width: 100%

--- a/libcal/custom-head.html
+++ b/libcal/custom-head.html
@@ -135,6 +135,11 @@ h3 {
   width: 100%
 }
 
+.header-main svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 @media only screen and (min-width:569px) {
   .header-main {
     width: 100%

--- a/libcal/custom-head.html
+++ b/libcal/custom-head.html
@@ -94,11 +94,6 @@ h3 {
   font-size: 20px;
 }
 
-svg {
-  max-width: 100%;
-  max-height: 100%;
-}
-
 .flex-container {
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -138,6 +138,11 @@ h3 {
   width: 100%
 }
 
+.header-main svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 @media only screen and (min-width:569px) {
   .header-main {
     width: 100%

--- a/libguides/custom-head.html
+++ b/libguides/custom-head.html
@@ -97,11 +97,6 @@ h3 {
   font-size: 20px;
 }
 
-svg {
-  max-width: 100%;
-  max-height: 100%;
-}
-
 .flex-container {
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -138,6 +138,11 @@ h3 {
   width: 100%
 }
 
+.header-main svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
 @media only screen and (min-width:569px) {
   .header-main {
     width: 100%

--- a/libwizard/custom-head.html
+++ b/libwizard/custom-head.html
@@ -97,11 +97,6 @@ h3 {
   font-size: 20px;
 }
 
-svg {
-  max-width: 100%;
-  max-height: 100%;
-}
-
 .flex-container {
   display: -webkit-flex;
   display: -ms-flexbox;


### PR DESCRIPTION
This fixes an issue that Stephanie identified with a shrinking MIT logo in the institute footer. Here's what it looks like on the libguides test page: https://libguides.mit.edu/mjbernha?b=g&d=a&group_id=3756

I should add that I'm not sure why that rule exists in the first place, so this could have unexpected consequences. My preference would have been to override it further in the CSS, but `height: auto` and `width: auto` didn't seem to get it done.