### PR TITLE
Footer changes applied to ArchivesSpace

### DIFF
--- a/archivesspace/mit-public-footer.html.erb
+++ b/archivesspace/mit-public-footer.html.erb
@@ -2,15 +2,18 @@
   <div class="row-fluid">
     <div class="col-sm-12">
       <div class="col-sm-6 profile">
-        <p>MASSACHUSETTS INSTITUTE OF TECHNOLOGY<br> 77 MASSACHUSETTS AVENUE<br> CAMBRIDGE MA 02139-4307.</p>
+        <p><a href="https://www.mit.edu/"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"></rect><rect width="5.8" height="28"></rect><rect x="9.6" width="5.8" height="18.8"></rect><rect x="19.3" width="5.8" height="28"></rect><rect x="38.5" y="8.9" width="5.8" height="19.1"></rect><rect x="38.8" width="15.2" height="5.6"></rect><rect x="28.9" width="5.8" height="5.6"></rect></svg></a>MASSACHUSETTS INSTITUTE OF TECHNOLOGY</p>
       </div>
       <div class="col-sm-6 links" style="margin-top:1em;">
-        <p><a href="https://libraries.mit.edu/distinctive-collections/ask/">Get Reference Help</a> | <a href="mailto:archivesspace-help@mit.edu"​>Submit a Correction</a></p>
-        <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/80x15.png" /></a>
-        <br>Metadata licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc/4.0/"> Creative Commons Attribution Non-Commercial License</a>.
+        <p>
+          <a href="https://libraries.mit.edu/distinctive-collections/ask/">Get Reference Help</a> | <a href="mailto:archivesspace-help@mit.edu"​>Submit a Correction</a>
+          <br>
+          <a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a> |
+          <a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a> |
+          <a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a>
+        </p>
+        <p>Metadata content created by MIT Libraries is <a rel="license" href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a>, unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us of copyright concerns.</a></p>
       </div>
     </div>
   </div>
 </div>
-
-

--- a/archivesspace/mit.css
+++ b/archivesspace/mit.css
@@ -1,9 +1,13 @@
 a { color: #337AB7; } 
 h1 { font-size: 1.75em; }
+.profile svg {
+	margin-right: 0.625rem;
+}
+.profile svg .color {
+	fill: #424242;
+}
 #footer_links a:link { color:#FFF; text-decoration:none; font-weight:normal; }
 #footer_links a:visited { color: #FFF; text-decoration:none; font-weight:normal; }
 #footer_links a:hover { color: #FFF; text-decoration:underline; font-weight:normal; }
 #footer_links a:active { color: #FFF; text-decoration:none; font-weight:normal; }
 #footer_links { color: #FFF; text-decoration:none; font-weight:normal; }
-
-

--- a/archivesspace/mitdev-public-footer.html.erb
+++ b/archivesspace/mitdev-public-footer.html.erb
@@ -2,15 +2,18 @@
   <div class="row-fluid">
     <div class="col-sm-12">
       <div class="col-sm-6 profile">
-        <p>MASSACHUSETTS INSTITUTE OF TECHNOLOGY<br> 77 MASSACHUSETTS AVENUE<br> CAMBRIDGE MA 02139-4307.</p>
+        <p><a href="https://www.mit.edu/"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="54" height="28" viewBox="0 0 54 28" enable-background="new 0 0 54 28" xml:space="preserve" class="logo-mit"><rect x="28.9" y="8.9" width="5.8" height="19.1" class="color"></rect><rect width="5.8" height="28"></rect><rect x="9.6" width="5.8" height="18.8"></rect><rect x="19.3" width="5.8" height="28"></rect><rect x="38.5" y="8.9" width="5.8" height="19.1"></rect><rect x="38.8" width="15.2" height="5.6"></rect><rect x="28.9" width="5.8" height="5.6"></rect></svg></a>MASSACHUSETTS INSTITUTE OF TECHNOLOGY</p>
       </div>
       <div class="col-sm-6 links" style="margin-top:1em;">
-        <p><a href="https://libraries.mit.edu/distinctive-collections/ask/">Get Reference Help</a> | <a href="mailto:archivesspace-help@mit.edu"​>Submit a Correction</a></p>
-        <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/80x15.png" /></a>
-        <br>Metadata licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc/4.0/"> Creative Commons Attribution Non-Commercial License</a>.
+        <p>
+          <a href="https://libraries.mit.edu/distinctive-collections/ask/">Get Reference Help</a> | <a href="mailto:archivesspace-help@mit.edu"​>Submit a Correction</a>
+          <br>
+          <a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a> |
+          <a href="https://libraries.mit.edu/permissions" class="link-sub">Permissions</a> |
+          <a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a>
+        </p>
+        <p>Metadata content created by MIT Libraries is <a rel="license" href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC</a>, unless otherwise noted. <a href="https://libraries.mit.edu/research-support/notices/copyright-notify/">Notify us of copyright concerns.</a></p>
       </div>
     </div>
   </div>
 </div>
-
-


### PR DESCRIPTION
Ticket: https://mitlibraries.atlassian.net/browse/UXWS-1022

**Please note** The markup being used for the policies menu is different here than it has been for other footers. This footer markup is so far away from all our other footers that it feels like more trouble than it is worth to use CSS-driven layouts for these three links. The menu just above is built old-school, so I've copied that style here.

This footer has been deployed to the ASpace dev site - I'll put the link in Slack / Jira